### PR TITLE
initial storm track fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .Rhistory
 .RData
 .Ruserdata
+.httr-oauth
+.remake
+*.zip
+*.rds

--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -4,14 +4,23 @@ include:
   - lib.yml
 
 packages:
+  - httr
 
 file_extensions:
-  - feather
   - ind
 
 sources:
+  - 1_fetch/src/fetch_storm_track.R
 
 targets:
 
   1_fetch:
     depends:
+      - 1_fetch/out/storm_track.zip
+
+  storm_track_cfg:
+    command: viz_config[I('storm_code')]
+  1_fetch/out/storm_track.zip.ind:
+    command: fetch_storm_track(ind_file=target_name, cfg=storm_track_cfg)
+  1_fetch/out/storm_track.zip:
+    command: gd_get('1_fetch/out/storm_track.zip.ind')

--- a/1_fetch/out/placeholder
+++ b/1_fetch/out/placeholder
@@ -1,1 +1,0 @@
-Placeholder

--- a/1_fetch/out/storm_track.zip.ind
+++ b/1_fetch/out/storm_track.zip.ind
@@ -1,0 +1,2 @@
+hash: 8d23d26b300289aa681fb4ece5fb2d0f
+

--- a/1_fetch/src/fetch_storm_track.R
+++ b/1_fetch/src/fetch_storm_track.R
@@ -1,0 +1,20 @@
+#' Download a storm track from the National Hurricane Center
+#'
+#' Go to https://www.nhc.noaa.gov/gis/archive_besttrack.php?year=2018 to see a list of options
+#'
+#' @param out_file character file name where the output should be saved
+#' @param storm_code the 8-digit character ID identifying a storm by the codes used at https://www.nhc.noaa.gov/gis/archive_besttrack.php?year=2018. The components are a 2-digit ocean ID ('al' or 'ep'), a 2-digit storm number (counts up from 01 throughout the year), and a 4-digit year. Go to the NHC website to identify the right code.
+#' year: 2017
+fetch_storm_track <- function(
+  ind_file,
+  cfg
+) {
+
+  # get from NHC
+  url <- sprintf("http://www.nhc.noaa.gov/gis/best_track/%s_best_track.zip", cfg$storm_code)
+  httr::GET(url, httr::write_disk(ind_file, overwrite=TRUE))
+
+  # post to Google Drive
+  data_file <- as_data_file(ind_file)
+  gd_put(remote_ind=ind_file, local_source=data_file, mock_get='none')
+}

--- a/1_fetch/src/placeholder
+++ b/1_fetch/src/placeholder
@@ -1,1 +1,0 @@
-Placeholder

--- a/2_process.yml
+++ b/2_process.yml
@@ -1,7 +1,7 @@
 target_default: 2_process
 
 include:
-  - lib.yml
+  - 1_fetch.yml
 
 packages:
 

--- a/6_visualize.yml
+++ b/6_visualize.yml
@@ -1,7 +1,7 @@
 target_default: 6_visualize
 
 include:
-  - lib.yml
+  - 2_process.yml
 
 packages:
 

--- a/build/status/MV9mZXRjaC9vdXQvc3Rvcm1fdHJhY2suemlwLmluZA.yml
+++ b/build/status/MV9mZXRjaC9vdXQvc3Rvcm1fdHJhY2suemlwLmluZA.yml
@@ -1,0 +1,12 @@
+version: 0.3.0
+name: 1_fetch/out/storm_track.zip.ind
+type: file
+hash: 2ea3ad86b9910f5d05fe1a669846f10d
+time: 2018-07-09 16:55:23 UTC
+depends:
+  storm_code: 25cb0c696ae9e1aa5b609a02c6d97c71
+fixed: 2f4367832f61e7160a3b28bde436e206
+code:
+  functions:
+    fetch_storm_track: 263cc2c171a4daebcfe06c00438ae916
+

--- a/lib.yml
+++ b/lib.yml
@@ -17,6 +17,9 @@ targets:
     depends:
       - lib/cfg/gd_config.yml
 
+  viz_config:
+    command: yaml.load_file('viz_config.yml')
+
   lib/cfg:
     command: dir.create(target_name, recursive=I(TRUE), showWarnings=I(FALSE))
 

--- a/remake.yml
+++ b/remake.yml
@@ -1,8 +1,7 @@
-target_default: visualize
+target_default: 6_visualize
 
 include:
-  - 1_fetch.yml
-  - 2_process.yml
+  - 6_visualize.yml
 
 targets:
 

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -1,0 +1,1 @@
+storm_code: al152017 # find the right code at https://www.nhc.noaa.gov/gis/archive_besttrack.php?year=2018


### PR DESCRIPTION
First step in #5 pipeline for storm track: download the .zip file from the national hurricane center.

Also got some project stuff going:

* viz_config.yml is the YAML file where we can put all our configuration parameters that will distinguish one storm from another

* I added an example of how I think we should use that viz_config: it's loaded for use by all files in lib.yml, so every remake recipe can assume the existence of `viz_config`. But there should be a lot of subsetting recipes, like this:
    ```yml
      storm_track_cfg:
        command: viz_config[I('storm_code')]
    ```
    where `storm_track_cfg` then gets passed into specific functions. If we don't use subsetting recipes, then anytime anything changes in the config, _everything_ will be considered out of date and will be rebuilt by remake/scipiper. That's no good, so these subsetting functions will help us only rerun what needs to be rerun. I predict that having function-specific cfg subsets, like `storm_track_cfg` going into `fetch_storm_track()`, will be convenient in case some viz_config elements are required for multiple subsets.

* I replumbed the 1_lib.yml, 1_fetch.yml, 2_process.yml, 6_visualize.yml, and remake.yml files just a bit so that each depends on the next - was needed to fix redundant `include`s from before this PR. The way I did this makes a strong coupling among phases, which I think should be OK/good for this relatively quick analysis pipeline. But we could opt for a decoupled approach if needed...