### PR TITLE
updating gif_tasks table, splitting viz_prep functions

### DIFF
--- a/5_vizprep/out/storm_point_[20170826-11]_fun.rds.ind
+++ b/5_vizprep/out/storm_point_[20170826-11]_fun.rds.ind
@@ -1,2 +1,0 @@
-hash: fd9c2af85640040fc06fa41e1509dd66
-

--- a/6_gif_tasks.yml
+++ b/6_gif_tasks.yml
@@ -1,0 +1,8048 @@
+# Do not edit - automatically generated
+# from the task_makefile.mustache template
+# by ::() via create_gif_makefile(),scipiper() via create_gif_makefile(),create_task_makefile() via create_gif_makefile()
+
+target_default: 6_gif_tasks
+
+include:
+  - 6_visualize.yml
+
+packages:
+  - dplyr
+  - scipiper
+
+sources:
+  - 6_visualize/src/create_storm_frame.R
+
+file_extensions:
+  - "feather"
+  - "ind"
+
+targets:
+  # --- a_2017-08-25_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-01].rds.ind')
+
+  # --- b_2017-08-25_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-01].rds.ind')
+
+  # --- c_2017-08-25_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-01].rds.ind')
+
+  # --- a_2017-08-25_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-02].rds.ind')
+
+  # --- b_2017-08-25_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-02].rds.ind')
+
+  # --- c_2017-08-25_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-02].rds.ind')
+
+  # --- a_2017-08-25_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-03].rds.ind')
+
+  # --- b_2017-08-25_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-03].rds.ind')
+
+  # --- c_2017-08-25_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-03].rds.ind')
+
+  # --- a_2017-08-25_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-04].rds.ind')
+
+  # --- b_2017-08-25_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-04].rds.ind')
+
+  # --- c_2017-08-25_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-04].rds.ind')
+
+  # --- a_2017-08-25_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-05].rds.ind')
+
+  # --- b_2017-08-25_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-05].rds.ind')
+
+  # --- c_2017-08-25_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-05].rds.ind')
+
+  # --- a_2017-08-25_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-06].rds.ind')
+
+  # --- b_2017-08-25_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-06].rds.ind')
+
+  # --- c_2017-08-25_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-06].rds.ind')
+
+  # --- a_2017-08-25_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-07].rds.ind')
+
+  # --- b_2017-08-25_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-07].rds.ind')
+
+  # --- c_2017-08-25_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-07].rds.ind')
+
+  # --- a_2017-08-25_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-08].rds.ind')
+
+  # --- b_2017-08-25_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-08].rds.ind')
+
+  # --- c_2017-08-25_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-08].rds.ind')
+
+  # --- a_2017-08-25_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-09].rds.ind')
+
+  # --- b_2017-08-25_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-09].rds.ind')
+
+  # --- c_2017-08-25_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-09].rds.ind')
+
+  # --- a_2017-08-25_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-10].rds.ind')
+
+  # --- b_2017-08-25_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-10].rds.ind')
+
+  # --- c_2017-08-25_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-10].rds.ind')
+
+  # --- a_2017-08-25_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-11].rds.ind')
+
+  # --- b_2017-08-25_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-11].rds.ind')
+
+  # --- c_2017-08-25_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-11].rds.ind')
+
+  # --- a_2017-08-25_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-12].rds.ind')
+
+  # --- b_2017-08-25_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-12].rds.ind')
+
+  # --- c_2017-08-25_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-12].rds.ind')
+
+  # --- a_2017-08-25_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-13].rds.ind')
+
+  # --- b_2017-08-25_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-13].rds.ind')
+
+  # --- c_2017-08-25_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-13].rds.ind')
+
+  # --- a_2017-08-25_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-14].rds.ind')
+
+  # --- b_2017-08-25_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-14].rds.ind')
+
+  # --- c_2017-08-25_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-14].rds.ind')
+
+  # --- a_2017-08-25_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-15].rds.ind')
+
+  # --- b_2017-08-25_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-15].rds.ind')
+
+  # --- c_2017-08-25_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-15].rds.ind')
+
+  # --- a_2017-08-25_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-16].rds.ind')
+
+  # --- b_2017-08-25_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-16].rds.ind')
+
+  # --- c_2017-08-25_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-16].rds.ind')
+
+  # --- a_2017-08-25_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-17].rds.ind')
+
+  # --- b_2017-08-25_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-17].rds.ind')
+
+  # --- c_2017-08-25_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-17].rds.ind')
+
+  # --- a_2017-08-25_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-18].rds.ind')
+
+  # --- b_2017-08-25_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-18].rds.ind')
+
+  # --- c_2017-08-25_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-18].rds.ind')
+
+  # --- a_2017-08-25_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-19].rds.ind')
+
+  # --- b_2017-08-25_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-19].rds.ind')
+
+  # --- c_2017-08-25_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-19].rds.ind')
+
+  # --- a_2017-08-25_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-20].rds.ind')
+
+  # --- b_2017-08-25_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-20].rds.ind')
+
+  # --- c_2017-08-25_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-20].rds.ind')
+
+  # --- a_2017-08-25_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-21].rds.ind')
+
+  # --- b_2017-08-25_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-21].rds.ind')
+
+  # --- c_2017-08-25_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-21].rds.ind')
+
+  # --- a_2017-08-25_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-22].rds.ind')
+
+  # --- b_2017-08-25_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-22].rds.ind')
+
+  # --- c_2017-08-25_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-22].rds.ind')
+
+  # --- a_2017-08-25_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-25_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-23].rds.ind')
+
+  # --- b_2017-08-25_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-25_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-23].rds.ind')
+
+  # --- c_2017-08-25_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-25_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170825-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170825-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170825-23].rds.ind')
+
+  # --- a_2017-08-26_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-00].rds.ind')
+
+  # --- b_2017-08-26_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-00].rds.ind')
+
+  # --- c_2017-08-26_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-00].rds.ind')
+
+  # --- a_2017-08-26_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-01].rds.ind')
+
+  # --- b_2017-08-26_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-01].rds.ind')
+
+  # --- c_2017-08-26_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-01].rds.ind')
+
+  # --- a_2017-08-26_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-02].rds.ind')
+
+  # --- b_2017-08-26_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-02].rds.ind')
+
+  # --- c_2017-08-26_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-02].rds.ind')
+
+  # --- a_2017-08-26_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-03].rds.ind')
+
+  # --- b_2017-08-26_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-03].rds.ind')
+
+  # --- c_2017-08-26_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-03].rds.ind')
+
+  # --- a_2017-08-26_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-04].rds.ind')
+
+  # --- b_2017-08-26_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-04].rds.ind')
+
+  # --- c_2017-08-26_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-04].rds.ind')
+
+  # --- a_2017-08-26_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-05].rds.ind')
+
+  # --- b_2017-08-26_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-05].rds.ind')
+
+  # --- c_2017-08-26_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-05].rds.ind')
+
+  # --- a_2017-08-26_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-06].rds.ind')
+
+  # --- b_2017-08-26_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-06].rds.ind')
+
+  # --- c_2017-08-26_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-06].rds.ind')
+
+  # --- a_2017-08-26_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-07].rds.ind')
+
+  # --- b_2017-08-26_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-07].rds.ind')
+
+  # --- c_2017-08-26_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-07].rds.ind')
+
+  # --- a_2017-08-26_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-08].rds.ind')
+
+  # --- b_2017-08-26_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-08].rds.ind')
+
+  # --- c_2017-08-26_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-08].rds.ind')
+
+  # --- a_2017-08-26_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-09].rds.ind')
+
+  # --- b_2017-08-26_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-09].rds.ind')
+
+  # --- c_2017-08-26_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-09].rds.ind')
+
+  # --- a_2017-08-26_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-10].rds.ind')
+
+  # --- b_2017-08-26_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-10].rds.ind')
+
+  # --- c_2017-08-26_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-10].rds.ind')
+
+  # --- a_2017-08-26_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-11].rds.ind')
+
+  # --- b_2017-08-26_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-11].rds.ind')
+
+  # --- c_2017-08-26_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-11].rds.ind')
+
+  # --- a_2017-08-26_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-12].rds.ind')
+
+  # --- b_2017-08-26_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-12].rds.ind')
+
+  # --- c_2017-08-26_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-12].rds.ind')
+
+  # --- a_2017-08-26_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-13].rds.ind')
+
+  # --- b_2017-08-26_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-13].rds.ind')
+
+  # --- c_2017-08-26_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-13].rds.ind')
+
+  # --- a_2017-08-26_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-14].rds.ind')
+
+  # --- b_2017-08-26_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-14].rds.ind')
+
+  # --- c_2017-08-26_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-14].rds.ind')
+
+  # --- a_2017-08-26_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-15].rds.ind')
+
+  # --- b_2017-08-26_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-15].rds.ind')
+
+  # --- c_2017-08-26_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-15].rds.ind')
+
+  # --- a_2017-08-26_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-16].rds.ind')
+
+  # --- b_2017-08-26_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-16].rds.ind')
+
+  # --- c_2017-08-26_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-16].rds.ind')
+
+  # --- a_2017-08-26_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-17].rds.ind')
+
+  # --- b_2017-08-26_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-17].rds.ind')
+
+  # --- c_2017-08-26_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-17].rds.ind')
+
+  # --- a_2017-08-26_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-18].rds.ind')
+
+  # --- b_2017-08-26_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-18].rds.ind')
+
+  # --- c_2017-08-26_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-18].rds.ind')
+
+  # --- a_2017-08-26_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-19].rds.ind')
+
+  # --- b_2017-08-26_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-19].rds.ind')
+
+  # --- c_2017-08-26_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-19].rds.ind')
+
+  # --- a_2017-08-26_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-20].rds.ind')
+
+  # --- b_2017-08-26_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-20].rds.ind')
+
+  # --- c_2017-08-26_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-20].rds.ind')
+
+  # --- a_2017-08-26_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-21].rds.ind')
+
+  # --- b_2017-08-26_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-21].rds.ind')
+
+  # --- c_2017-08-26_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-21].rds.ind')
+
+  # --- a_2017-08-26_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-22].rds.ind')
+
+  # --- b_2017-08-26_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-22].rds.ind')
+
+  # --- c_2017-08-26_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-22].rds.ind')
+
+  # --- a_2017-08-26_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-26_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-23].rds.ind')
+
+  # --- b_2017-08-26_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-26_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-23].rds.ind')
+
+  # --- c_2017-08-26_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-26_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170826-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170826-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170826-23].rds.ind')
+
+  # --- a_2017-08-27_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-00].rds.ind')
+
+  # --- b_2017-08-27_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-00].rds.ind')
+
+  # --- c_2017-08-27_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-00].rds.ind')
+
+  # --- a_2017-08-27_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-01].rds.ind')
+
+  # --- b_2017-08-27_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-01].rds.ind')
+
+  # --- c_2017-08-27_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-01].rds.ind')
+
+  # --- a_2017-08-27_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-02].rds.ind')
+
+  # --- b_2017-08-27_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-02].rds.ind')
+
+  # --- c_2017-08-27_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-02].rds.ind')
+
+  # --- a_2017-08-27_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-03].rds.ind')
+
+  # --- b_2017-08-27_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-03].rds.ind')
+
+  # --- c_2017-08-27_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-03].rds.ind')
+
+  # --- a_2017-08-27_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-04].rds.ind')
+
+  # --- b_2017-08-27_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-04].rds.ind')
+
+  # --- c_2017-08-27_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-04].rds.ind')
+
+  # --- a_2017-08-27_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-05].rds.ind')
+
+  # --- b_2017-08-27_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-05].rds.ind')
+
+  # --- c_2017-08-27_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-05].rds.ind')
+
+  # --- a_2017-08-27_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-06].rds.ind')
+
+  # --- b_2017-08-27_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-06].rds.ind')
+
+  # --- c_2017-08-27_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-06].rds.ind')
+
+  # --- a_2017-08-27_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-07].rds.ind')
+
+  # --- b_2017-08-27_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-07].rds.ind')
+
+  # --- c_2017-08-27_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-07].rds.ind')
+
+  # --- a_2017-08-27_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-08].rds.ind')
+
+  # --- b_2017-08-27_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-08].rds.ind')
+
+  # --- c_2017-08-27_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-08].rds.ind')
+
+  # --- a_2017-08-27_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-09].rds.ind')
+
+  # --- b_2017-08-27_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-09].rds.ind')
+
+  # --- c_2017-08-27_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-09].rds.ind')
+
+  # --- a_2017-08-27_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-10].rds.ind')
+
+  # --- b_2017-08-27_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-10].rds.ind')
+
+  # --- c_2017-08-27_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-10].rds.ind')
+
+  # --- a_2017-08-27_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-11].rds.ind')
+
+  # --- b_2017-08-27_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-11].rds.ind')
+
+  # --- c_2017-08-27_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-11].rds.ind')
+
+  # --- a_2017-08-27_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-12].rds.ind')
+
+  # --- b_2017-08-27_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-12].rds.ind')
+
+  # --- c_2017-08-27_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-12].rds.ind')
+
+  # --- a_2017-08-27_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-13].rds.ind')
+
+  # --- b_2017-08-27_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-13].rds.ind')
+
+  # --- c_2017-08-27_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-13].rds.ind')
+
+  # --- a_2017-08-27_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-14].rds.ind')
+
+  # --- b_2017-08-27_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-14].rds.ind')
+
+  # --- c_2017-08-27_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-14].rds.ind')
+
+  # --- a_2017-08-27_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-15].rds.ind')
+
+  # --- b_2017-08-27_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-15].rds.ind')
+
+  # --- c_2017-08-27_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-15].rds.ind')
+
+  # --- a_2017-08-27_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-16].rds.ind')
+
+  # --- b_2017-08-27_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-16].rds.ind')
+
+  # --- c_2017-08-27_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-16].rds.ind')
+
+  # --- a_2017-08-27_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-17].rds.ind')
+
+  # --- b_2017-08-27_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-17].rds.ind')
+
+  # --- c_2017-08-27_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-17].rds.ind')
+
+  # --- a_2017-08-27_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-18].rds.ind')
+
+  # --- b_2017-08-27_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-18].rds.ind')
+
+  # --- c_2017-08-27_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-18].rds.ind')
+
+  # --- a_2017-08-27_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-19].rds.ind')
+
+  # --- b_2017-08-27_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-19].rds.ind')
+
+  # --- c_2017-08-27_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-19].rds.ind')
+
+  # --- a_2017-08-27_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-20].rds.ind')
+
+  # --- b_2017-08-27_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-20].rds.ind')
+
+  # --- c_2017-08-27_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-20].rds.ind')
+
+  # --- a_2017-08-27_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-21].rds.ind')
+
+  # --- b_2017-08-27_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-21].rds.ind')
+
+  # --- c_2017-08-27_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-21].rds.ind')
+
+  # --- a_2017-08-27_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-22].rds.ind')
+
+  # --- b_2017-08-27_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-22].rds.ind')
+
+  # --- c_2017-08-27_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-22].rds.ind')
+
+  # --- a_2017-08-27_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-27_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-23].rds.ind')
+
+  # --- b_2017-08-27_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-27_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-23].rds.ind')
+
+  # --- c_2017-08-27_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-27_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170827-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170827-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170827-23].rds.ind')
+
+  # --- a_2017-08-28_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-00].rds.ind')
+
+  # --- b_2017-08-28_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-00].rds.ind')
+
+  # --- c_2017-08-28_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-00].rds.ind')
+
+  # --- a_2017-08-28_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-01].rds.ind')
+
+  # --- b_2017-08-28_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-01].rds.ind')
+
+  # --- c_2017-08-28_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-01].rds.ind')
+
+  # --- a_2017-08-28_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-02].rds.ind')
+
+  # --- b_2017-08-28_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-02].rds.ind')
+
+  # --- c_2017-08-28_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-02].rds.ind')
+
+  # --- a_2017-08-28_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-03].rds.ind')
+
+  # --- b_2017-08-28_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-03].rds.ind')
+
+  # --- c_2017-08-28_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-03].rds.ind')
+
+  # --- a_2017-08-28_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-04].rds.ind')
+
+  # --- b_2017-08-28_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-04].rds.ind')
+
+  # --- c_2017-08-28_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-04].rds.ind')
+
+  # --- a_2017-08-28_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-05].rds.ind')
+
+  # --- b_2017-08-28_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-05].rds.ind')
+
+  # --- c_2017-08-28_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-05].rds.ind')
+
+  # --- a_2017-08-28_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-06].rds.ind')
+
+  # --- b_2017-08-28_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-06].rds.ind')
+
+  # --- c_2017-08-28_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-06].rds.ind')
+
+  # --- a_2017-08-28_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-07].rds.ind')
+
+  # --- b_2017-08-28_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-07].rds.ind')
+
+  # --- c_2017-08-28_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-07].rds.ind')
+
+  # --- a_2017-08-28_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-08].rds.ind')
+
+  # --- b_2017-08-28_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-08].rds.ind')
+
+  # --- c_2017-08-28_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-08].rds.ind')
+
+  # --- a_2017-08-28_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-09].rds.ind')
+
+  # --- b_2017-08-28_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-09].rds.ind')
+
+  # --- c_2017-08-28_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-09].rds.ind')
+
+  # --- a_2017-08-28_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-10].rds.ind')
+
+  # --- b_2017-08-28_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-10].rds.ind')
+
+  # --- c_2017-08-28_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-10].rds.ind')
+
+  # --- a_2017-08-28_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-11].rds.ind')
+
+  # --- b_2017-08-28_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-11].rds.ind')
+
+  # --- c_2017-08-28_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-11].rds.ind')
+
+  # --- a_2017-08-28_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-12].rds.ind')
+
+  # --- b_2017-08-28_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-12].rds.ind')
+
+  # --- c_2017-08-28_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-12].rds.ind')
+
+  # --- a_2017-08-28_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-13].rds.ind')
+
+  # --- b_2017-08-28_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-13].rds.ind')
+
+  # --- c_2017-08-28_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-13].rds.ind')
+
+  # --- a_2017-08-28_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-14].rds.ind')
+
+  # --- b_2017-08-28_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-14].rds.ind')
+
+  # --- c_2017-08-28_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-14].rds.ind')
+
+  # --- a_2017-08-28_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-15].rds.ind')
+
+  # --- b_2017-08-28_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-15].rds.ind')
+
+  # --- c_2017-08-28_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-15].rds.ind')
+
+  # --- a_2017-08-28_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-16].rds.ind')
+
+  # --- b_2017-08-28_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-16].rds.ind')
+
+  # --- c_2017-08-28_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-16].rds.ind')
+
+  # --- a_2017-08-28_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-17].rds.ind')
+
+  # --- b_2017-08-28_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-17].rds.ind')
+
+  # --- c_2017-08-28_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-17].rds.ind')
+
+  # --- a_2017-08-28_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-18].rds.ind')
+
+  # --- b_2017-08-28_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-18].rds.ind')
+
+  # --- c_2017-08-28_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-18].rds.ind')
+
+  # --- a_2017-08-28_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-19].rds.ind')
+
+  # --- b_2017-08-28_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-19].rds.ind')
+
+  # --- c_2017-08-28_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-19].rds.ind')
+
+  # --- a_2017-08-28_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-20].rds.ind')
+
+  # --- b_2017-08-28_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-20].rds.ind')
+
+  # --- c_2017-08-28_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-20].rds.ind')
+
+  # --- a_2017-08-28_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-21].rds.ind')
+
+  # --- b_2017-08-28_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-21].rds.ind')
+
+  # --- c_2017-08-28_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-21].rds.ind')
+
+  # --- a_2017-08-28_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-22].rds.ind')
+
+  # --- b_2017-08-28_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-22].rds.ind')
+
+  # --- c_2017-08-28_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-22].rds.ind')
+
+  # --- a_2017-08-28_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-28_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-23].rds.ind')
+
+  # --- b_2017-08-28_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-28_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-23].rds.ind')
+
+  # --- c_2017-08-28_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-28_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170828-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170828-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170828-23].rds.ind')
+
+  # --- a_2017-08-29_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-00].rds.ind')
+
+  # --- b_2017-08-29_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-00].rds.ind')
+
+  # --- c_2017-08-29_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-00].rds.ind')
+
+  # --- a_2017-08-29_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-01].rds.ind')
+
+  # --- b_2017-08-29_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-01].rds.ind')
+
+  # --- c_2017-08-29_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-01].rds.ind')
+
+  # --- a_2017-08-29_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-02].rds.ind')
+
+  # --- b_2017-08-29_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-02].rds.ind')
+
+  # --- c_2017-08-29_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-02].rds.ind')
+
+  # --- a_2017-08-29_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-03].rds.ind')
+
+  # --- b_2017-08-29_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-03].rds.ind')
+
+  # --- c_2017-08-29_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-03].rds.ind')
+
+  # --- a_2017-08-29_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-04].rds.ind')
+
+  # --- b_2017-08-29_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-04].rds.ind')
+
+  # --- c_2017-08-29_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-04].rds.ind')
+
+  # --- a_2017-08-29_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-05].rds.ind')
+
+  # --- b_2017-08-29_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-05].rds.ind')
+
+  # --- c_2017-08-29_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-05].rds.ind')
+
+  # --- a_2017-08-29_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-06].rds.ind')
+
+  # --- b_2017-08-29_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-06].rds.ind')
+
+  # --- c_2017-08-29_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-06].rds.ind')
+
+  # --- a_2017-08-29_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-07].rds.ind')
+
+  # --- b_2017-08-29_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-07].rds.ind')
+
+  # --- c_2017-08-29_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-07].rds.ind')
+
+  # --- a_2017-08-29_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-08].rds.ind')
+
+  # --- b_2017-08-29_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-08].rds.ind')
+
+  # --- c_2017-08-29_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-08].rds.ind')
+
+  # --- a_2017-08-29_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-09].rds.ind')
+
+  # --- b_2017-08-29_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-09].rds.ind')
+
+  # --- c_2017-08-29_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-09].rds.ind')
+
+  # --- a_2017-08-29_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-10].rds.ind')
+
+  # --- b_2017-08-29_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-10].rds.ind')
+
+  # --- c_2017-08-29_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-10].rds.ind')
+
+  # --- a_2017-08-29_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-11].rds.ind')
+
+  # --- b_2017-08-29_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-11].rds.ind')
+
+  # --- c_2017-08-29_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-11].rds.ind')
+
+  # --- a_2017-08-29_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-12].rds.ind')
+
+  # --- b_2017-08-29_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-12].rds.ind')
+
+  # --- c_2017-08-29_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-12].rds.ind')
+
+  # --- a_2017-08-29_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-13].rds.ind')
+
+  # --- b_2017-08-29_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-13].rds.ind')
+
+  # --- c_2017-08-29_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-13].rds.ind')
+
+  # --- a_2017-08-29_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-14].rds.ind')
+
+  # --- b_2017-08-29_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-14].rds.ind')
+
+  # --- c_2017-08-29_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-14].rds.ind')
+
+  # --- a_2017-08-29_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-15].rds.ind')
+
+  # --- b_2017-08-29_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-15].rds.ind')
+
+  # --- c_2017-08-29_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-15].rds.ind')
+
+  # --- a_2017-08-29_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-16].rds.ind')
+
+  # --- b_2017-08-29_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-16].rds.ind')
+
+  # --- c_2017-08-29_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-16].rds.ind')
+
+  # --- a_2017-08-29_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-17].rds.ind')
+
+  # --- b_2017-08-29_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-17].rds.ind')
+
+  # --- c_2017-08-29_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-17].rds.ind')
+
+  # --- a_2017-08-29_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-18].rds.ind')
+
+  # --- b_2017-08-29_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-18].rds.ind')
+
+  # --- c_2017-08-29_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-18].rds.ind')
+
+  # --- a_2017-08-29_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-19].rds.ind')
+
+  # --- b_2017-08-29_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-19].rds.ind')
+
+  # --- c_2017-08-29_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-19].rds.ind')
+
+  # --- a_2017-08-29_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-20].rds.ind')
+
+  # --- b_2017-08-29_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-20].rds.ind')
+
+  # --- c_2017-08-29_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-20].rds.ind')
+
+  # --- a_2017-08-29_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-21].rds.ind')
+
+  # --- b_2017-08-29_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-21].rds.ind')
+
+  # --- c_2017-08-29_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-21].rds.ind')
+
+  # --- a_2017-08-29_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-22].rds.ind')
+
+  # --- b_2017-08-29_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-22].rds.ind')
+
+  # --- c_2017-08-29_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-22].rds.ind')
+
+  # --- a_2017-08-29_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-29_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-23].rds.ind')
+
+  # --- b_2017-08-29_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-29_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-23].rds.ind')
+
+  # --- c_2017-08-29_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-29_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170829-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170829-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170829-23].rds.ind')
+
+  # --- a_2017-08-30_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-00].rds.ind')
+
+  # --- b_2017-08-30_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-00].rds.ind')
+
+  # --- c_2017-08-30_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-00].rds.ind')
+
+  # --- a_2017-08-30_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-01].rds.ind')
+
+  # --- b_2017-08-30_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-01].rds.ind')
+
+  # --- c_2017-08-30_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-01].rds.ind')
+
+  # --- a_2017-08-30_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-02].rds.ind')
+
+  # --- b_2017-08-30_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-02].rds.ind')
+
+  # --- c_2017-08-30_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-02].rds.ind')
+
+  # --- a_2017-08-30_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-03].rds.ind')
+
+  # --- b_2017-08-30_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-03].rds.ind')
+
+  # --- c_2017-08-30_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-03].rds.ind')
+
+  # --- a_2017-08-30_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-04].rds.ind')
+
+  # --- b_2017-08-30_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-04].rds.ind')
+
+  # --- c_2017-08-30_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-04].rds.ind')
+
+  # --- a_2017-08-30_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-05].rds.ind')
+
+  # --- b_2017-08-30_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-05].rds.ind')
+
+  # --- c_2017-08-30_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-05].rds.ind')
+
+  # --- a_2017-08-30_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-06].rds.ind')
+
+  # --- b_2017-08-30_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-06].rds.ind')
+
+  # --- c_2017-08-30_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-06].rds.ind')
+
+  # --- a_2017-08-30_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-07].rds.ind')
+
+  # --- b_2017-08-30_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-07].rds.ind')
+
+  # --- c_2017-08-30_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-07].rds.ind')
+
+  # --- a_2017-08-30_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-08].rds.ind')
+
+  # --- b_2017-08-30_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-08].rds.ind')
+
+  # --- c_2017-08-30_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-08].rds.ind')
+
+  # --- a_2017-08-30_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-09].rds.ind')
+
+  # --- b_2017-08-30_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-09].rds.ind')
+
+  # --- c_2017-08-30_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-09].rds.ind')
+
+  # --- a_2017-08-30_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-10].rds.ind')
+
+  # --- b_2017-08-30_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-10].rds.ind')
+
+  # --- c_2017-08-30_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-10].rds.ind')
+
+  # --- a_2017-08-30_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-11].rds.ind')
+
+  # --- b_2017-08-30_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-11].rds.ind')
+
+  # --- c_2017-08-30_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-11].rds.ind')
+
+  # --- a_2017-08-30_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-12].rds.ind')
+
+  # --- b_2017-08-30_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-12].rds.ind')
+
+  # --- c_2017-08-30_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-12].rds.ind')
+
+  # --- a_2017-08-30_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-13].rds.ind')
+
+  # --- b_2017-08-30_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-13].rds.ind')
+
+  # --- c_2017-08-30_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-13].rds.ind')
+
+  # --- a_2017-08-30_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-14].rds.ind')
+
+  # --- b_2017-08-30_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-14].rds.ind')
+
+  # --- c_2017-08-30_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-14].rds.ind')
+
+  # --- a_2017-08-30_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-15].rds.ind')
+
+  # --- b_2017-08-30_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-15].rds.ind')
+
+  # --- c_2017-08-30_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-15].rds.ind')
+
+  # --- a_2017-08-30_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-16].rds.ind')
+
+  # --- b_2017-08-30_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-16].rds.ind')
+
+  # --- c_2017-08-30_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-16].rds.ind')
+
+  # --- a_2017-08-30_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-17].rds.ind')
+
+  # --- b_2017-08-30_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-17].rds.ind')
+
+  # --- c_2017-08-30_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-17].rds.ind')
+
+  # --- a_2017-08-30_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-18].rds.ind')
+
+  # --- b_2017-08-30_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-18].rds.ind')
+
+  # --- c_2017-08-30_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-18].rds.ind')
+
+  # --- a_2017-08-30_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-19].rds.ind')
+
+  # --- b_2017-08-30_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-19].rds.ind')
+
+  # --- c_2017-08-30_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-19].rds.ind')
+
+  # --- a_2017-08-30_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-20].rds.ind')
+
+  # --- b_2017-08-30_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-20].rds.ind')
+
+  # --- c_2017-08-30_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-20].rds.ind')
+
+  # --- a_2017-08-30_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-21].rds.ind')
+
+  # --- b_2017-08-30_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-21].rds.ind')
+
+  # --- c_2017-08-30_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-21].rds.ind')
+
+  # --- a_2017-08-30_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-22].rds.ind')
+
+  # --- b_2017-08-30_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-22].rds.ind')
+
+  # --- c_2017-08-30_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-22].rds.ind')
+
+  # --- a_2017-08-30_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-30_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-23].rds.ind')
+
+  # --- b_2017-08-30_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-30_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-23].rds.ind')
+
+  # --- c_2017-08-30_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-30_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170830-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170830-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170830-23].rds.ind')
+
+  # --- a_2017-08-31_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-00].rds.ind')
+
+  # --- b_2017-08-31_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-00].rds.ind')
+
+  # --- c_2017-08-31_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-00].rds.ind')
+
+  # --- a_2017-08-31_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-01].rds.ind')
+
+  # --- b_2017-08-31_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-01].rds.ind')
+
+  # --- c_2017-08-31_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-01].rds.ind')
+
+  # --- a_2017-08-31_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-02].rds.ind')
+
+  # --- b_2017-08-31_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-02].rds.ind')
+
+  # --- c_2017-08-31_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-02].rds.ind')
+
+  # --- a_2017-08-31_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-03].rds.ind')
+
+  # --- b_2017-08-31_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-03].rds.ind')
+
+  # --- c_2017-08-31_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-03].rds.ind')
+
+  # --- a_2017-08-31_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-04].rds.ind')
+
+  # --- b_2017-08-31_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-04].rds.ind')
+
+  # --- c_2017-08-31_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-04].rds.ind')
+
+  # --- a_2017-08-31_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-05].rds.ind')
+
+  # --- b_2017-08-31_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-05].rds.ind')
+
+  # --- c_2017-08-31_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-05].rds.ind')
+
+  # --- a_2017-08-31_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-06].rds.ind')
+
+  # --- b_2017-08-31_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-06].rds.ind')
+
+  # --- c_2017-08-31_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-06].rds.ind')
+
+  # --- a_2017-08-31_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-07].rds.ind')
+
+  # --- b_2017-08-31_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-07].rds.ind')
+
+  # --- c_2017-08-31_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-07].rds.ind')
+
+  # --- a_2017-08-31_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-08].rds.ind')
+
+  # --- b_2017-08-31_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-08].rds.ind')
+
+  # --- c_2017-08-31_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-08].rds.ind')
+
+  # --- a_2017-08-31_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-09].rds.ind')
+
+  # --- b_2017-08-31_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-09].rds.ind')
+
+  # --- c_2017-08-31_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-09].rds.ind')
+
+  # --- a_2017-08-31_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-10].rds.ind')
+
+  # --- b_2017-08-31_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-10].rds.ind')
+
+  # --- c_2017-08-31_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-10].rds.ind')
+
+  # --- a_2017-08-31_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-11].rds.ind')
+
+  # --- b_2017-08-31_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-11].rds.ind')
+
+  # --- c_2017-08-31_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-11].rds.ind')
+
+  # --- a_2017-08-31_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-12].rds.ind')
+
+  # --- b_2017-08-31_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-12].rds.ind')
+
+  # --- c_2017-08-31_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-12].rds.ind')
+
+  # --- a_2017-08-31_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-13].rds.ind')
+
+  # --- b_2017-08-31_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-13].rds.ind')
+
+  # --- c_2017-08-31_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-13].rds.ind')
+
+  # --- a_2017-08-31_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-14].rds.ind')
+
+  # --- b_2017-08-31_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-14].rds.ind')
+
+  # --- c_2017-08-31_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-14].rds.ind')
+
+  # --- a_2017-08-31_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-15].rds.ind')
+
+  # --- b_2017-08-31_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-15].rds.ind')
+
+  # --- c_2017-08-31_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-15].rds.ind')
+
+  # --- a_2017-08-31_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-16].rds.ind')
+
+  # --- b_2017-08-31_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-16].rds.ind')
+
+  # --- c_2017-08-31_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-16].rds.ind')
+
+  # --- a_2017-08-31_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-17].rds.ind')
+
+  # --- b_2017-08-31_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-17].rds.ind')
+
+  # --- c_2017-08-31_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-17].rds.ind')
+
+  # --- a_2017-08-31_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-18].rds.ind')
+
+  # --- b_2017-08-31_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-18].rds.ind')
+
+  # --- c_2017-08-31_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-18].rds.ind')
+
+  # --- a_2017-08-31_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-19].rds.ind')
+
+  # --- b_2017-08-31_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-19].rds.ind')
+
+  # --- c_2017-08-31_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-19].rds.ind')
+
+  # --- a_2017-08-31_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-20].rds.ind')
+
+  # --- b_2017-08-31_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-20].rds.ind')
+
+  # --- c_2017-08-31_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-20].rds.ind')
+
+  # --- a_2017-08-31_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-21].rds.ind')
+
+  # --- b_2017-08-31_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-21].rds.ind')
+
+  # --- c_2017-08-31_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-21].rds.ind')
+
+  # --- a_2017-08-31_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-22].rds.ind')
+
+  # --- b_2017-08-31_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-22].rds.ind')
+
+  # --- c_2017-08-31_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-22].rds.ind')
+
+  # --- a_2017-08-31_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-08-31_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-23].rds.ind')
+
+  # --- b_2017-08-31_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-08-31_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-23].rds.ind')
+
+  # --- c_2017-08-31_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-08-31_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170831-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170831-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170831-23].rds.ind')
+
+  # --- a_2017-09-01_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-00].rds.ind')
+
+  # --- b_2017-09-01_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-00].rds.ind')
+
+  # --- c_2017-09-01_00:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_00:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-00].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-00].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-00].rds.ind')
+
+  # --- a_2017-09-01_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-01].rds.ind')
+
+  # --- b_2017-09-01_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-01].rds.ind')
+
+  # --- c_2017-09-01_01:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_01:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-01].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-01].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-01].rds.ind')
+
+  # --- a_2017-09-01_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-02].rds.ind')
+
+  # --- b_2017-09-01_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-02].rds.ind')
+
+  # --- c_2017-09-01_02:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_02:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-02].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-02].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-02].rds.ind')
+
+  # --- a_2017-09-01_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-03].rds.ind')
+
+  # --- b_2017-09-01_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-03].rds.ind')
+
+  # --- c_2017-09-01_03:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_03:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-03].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-03].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-03].rds.ind')
+
+  # --- a_2017-09-01_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-04].rds.ind')
+
+  # --- b_2017-09-01_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-04].rds.ind')
+
+  # --- c_2017-09-01_04:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_04:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-04].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-04].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-04].rds.ind')
+
+  # --- a_2017-09-01_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-05].rds.ind')
+
+  # --- b_2017-09-01_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-05].rds.ind')
+
+  # --- c_2017-09-01_05:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_05:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-05].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-05].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-05].rds.ind')
+
+  # --- a_2017-09-01_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-06].rds.ind')
+
+  # --- b_2017-09-01_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-06].rds.ind')
+
+  # --- c_2017-09-01_06:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_06:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-06].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-06].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-06].rds.ind')
+
+  # --- a_2017-09-01_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-07].rds.ind')
+
+  # --- b_2017-09-01_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-07].rds.ind')
+
+  # --- c_2017-09-01_07:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_07:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-07].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-07].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-07].rds.ind')
+
+  # --- a_2017-09-01_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-08].rds.ind')
+
+  # --- b_2017-09-01_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-08].rds.ind')
+
+  # --- c_2017-09-01_08:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_08:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-08].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-08].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-08].rds.ind')
+
+  # --- a_2017-09-01_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-09].rds.ind')
+
+  # --- b_2017-09-01_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-09].rds.ind')
+
+  # --- c_2017-09-01_09:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_09:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-09].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-09].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-09].rds.ind')
+
+  # --- a_2017-09-01_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-10].rds.ind')
+
+  # --- b_2017-09-01_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-10].rds.ind')
+
+  # --- c_2017-09-01_10:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_10:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-10].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-10].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-10].rds.ind')
+
+  # --- a_2017-09-01_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-11].rds.ind')
+
+  # --- b_2017-09-01_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-11].rds.ind')
+
+  # --- c_2017-09-01_11:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_11:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-11].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-11].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-11].rds.ind')
+
+  # --- a_2017-09-01_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-12].rds.ind')
+
+  # --- b_2017-09-01_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-12].rds.ind')
+
+  # --- c_2017-09-01_12:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_12:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-12].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-12].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-12].rds.ind')
+
+  # --- a_2017-09-01_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-13].rds.ind')
+
+  # --- b_2017-09-01_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-13].rds.ind')
+
+  # --- c_2017-09-01_13:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_13:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-13].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-13].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-13].rds.ind')
+
+  # --- a_2017-09-01_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-14].rds.ind')
+
+  # --- b_2017-09-01_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-14].rds.ind')
+
+  # --- c_2017-09-01_14:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_14:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-14].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-14].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-14].rds.ind')
+
+  # --- a_2017-09-01_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-15].rds.ind')
+
+  # --- b_2017-09-01_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-15].rds.ind')
+
+  # --- c_2017-09-01_15:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_15:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-15].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-15].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-15].rds.ind')
+
+  # --- a_2017-09-01_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-16].rds.ind')
+
+  # --- b_2017-09-01_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-16].rds.ind')
+
+  # --- c_2017-09-01_16:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_16:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-16].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-16].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-16].rds.ind')
+
+  # --- a_2017-09-01_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-17].rds.ind')
+
+  # --- b_2017-09-01_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-17].rds.ind')
+
+  # --- c_2017-09-01_17:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_17:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-17].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-17].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-17].rds.ind')
+
+  # --- a_2017-09-01_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-18].rds.ind')
+
+  # --- b_2017-09-01_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-18].rds.ind')
+
+  # --- c_2017-09-01_18:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_18:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-18].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-18].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-18].rds.ind')
+
+  # --- a_2017-09-01_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-19].rds.ind')
+
+  # --- b_2017-09-01_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-19].rds.ind')
+
+  # --- c_2017-09-01_19:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_19:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-19].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-19].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-19].rds.ind')
+
+  # --- a_2017-09-01_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-20].rds.ind')
+
+  # --- b_2017-09-01_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-20].rds.ind')
+
+  # --- c_2017-09-01_20:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_20:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-20].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-20].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-20].rds.ind')
+
+  # --- a_2017-09-01_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-21].rds.ind')
+
+  # --- b_2017-09-01_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-21].rds.ind')
+
+  # --- c_2017-09-01_21:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_21:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-21].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-21].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-21].rds.ind')
+
+  # --- a_2017-09-01_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-22].rds.ind')
+
+  # --- b_2017-09-01_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-22].rds.ind')
+
+  # --- c_2017-09-01_22:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_22:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-22].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-22].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-22].rds.ind')
+
+  # --- a_2017-09-01_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_a_2017-09-01_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-23].rds.ind')
+
+  # --- b_2017-09-01_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_b_2017-09-01_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-23].rds.ind')
+
+  # --- c_2017-09-01_23:00:00 --- #
+  
+  6_visualize/tmp/gif_frame_c_2017-09-01_23:00:00.png:
+    command: create_storm_frame(
+      png_file=target_name
+      config=storm_frame_config,
+      '6_vizprep/out/view_fun.rds.ind',
+      '6_vizprep/out/basemap_fun.rds.ind',
+      '6_vizprep/out/storm_line_fun.rds.ind'
+      '6_vizprep/out/storm_point_[20170901-23].rds.ind',
+      '6_vizprep/out/precip_raster_[20170901-23].rds.ind',
+      '6_vizprep/out/streamdata_[20170901-23].rds.ind')
+
+  # --- Overall job --- #
+
+  6_gif_tasks:
+    command: sc_indicate(I('6_visualize/log/6_gif_tasks.ind'), hash_depends=I(TRUE), depends_target=I('6_gif_tasks'), depends_makefile=I('6_gif_tasks.yml'))
+    depends: 
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_01:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_01:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_01:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_02:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_02:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_02:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_03:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_03:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_03:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_04:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_04:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_04:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_05:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_05:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_05:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_06:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_06:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_06:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_07:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_07:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_07:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_08:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_08:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_08:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_09:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_09:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_09:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_10:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_10:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_10:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_11:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_11:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_11:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_12:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_12:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_12:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_13:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_13:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_13:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_14:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_14:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_14:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_15:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_15:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_15:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_16:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_16:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_16:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_17:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_17:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_17:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_18:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_18:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_18:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_19:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_19:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_19:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_20:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_20:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_20:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_21:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_21:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_21:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_22:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_22:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_22:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-25_23:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-25_23:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-25_23:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_00:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_00:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_00:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_01:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_01:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_01:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_02:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_02:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_02:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_03:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_03:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_03:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_04:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_04:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_04:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_05:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_05:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_05:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_06:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_06:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_06:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_07:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_07:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_07:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_08:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_08:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_08:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_09:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_09:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_09:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_10:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_10:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_10:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_11:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_11:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_11:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_12:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_12:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_12:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_13:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_13:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_13:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_14:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_14:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_14:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_15:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_15:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_15:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_16:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_16:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_16:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_17:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_17:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_17:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_18:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_18:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_18:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_19:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_19:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_19:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_20:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_20:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_20:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_21:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_21:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_21:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_22:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_22:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_22:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-26_23:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-26_23:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-26_23:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_00:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_00:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_00:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_01:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_01:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_01:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_02:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_02:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_02:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_03:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_03:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_03:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_04:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_04:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_04:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_05:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_05:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_05:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_06:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_06:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_06:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_07:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_07:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_07:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_08:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_08:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_08:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_09:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_09:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_09:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_10:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_10:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_10:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_11:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_11:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_11:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_12:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_12:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_12:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_13:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_13:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_13:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_14:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_14:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_14:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_15:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_15:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_15:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_16:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_16:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_16:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_17:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_17:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_17:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_18:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_18:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_18:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_19:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_19:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_19:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_20:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_20:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_20:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_21:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_21:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_21:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_22:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_22:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_22:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-27_23:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-27_23:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-27_23:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_00:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_00:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_00:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_01:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_01:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_01:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_02:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_02:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_02:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_03:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_03:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_03:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_04:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_04:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_04:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_05:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_05:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_05:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_06:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_06:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_06:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_07:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_07:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_07:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_08:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_08:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_08:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_09:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_09:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_09:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_10:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_10:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_10:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_11:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_11:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_11:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_12:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_12:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_12:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_13:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_13:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_13:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_14:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_14:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_14:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_15:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_15:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_15:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_16:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_16:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_16:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_17:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_17:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_17:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_18:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_18:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_18:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_19:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_19:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_19:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_20:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_20:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_20:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_21:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_21:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_21:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_22:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_22:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_22:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-28_23:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-28_23:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-28_23:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_00:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_00:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_00:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_01:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_01:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_01:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_02:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_02:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_02:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_03:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_03:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_03:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_04:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_04:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_04:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_05:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_05:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_05:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_06:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_06:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_06:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_07:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_07:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_07:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_08:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_08:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_08:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_09:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_09:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_09:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_10:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_10:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_10:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_11:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_11:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_11:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_12:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_12:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_12:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_13:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_13:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_13:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_14:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_14:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_14:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_15:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_15:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_15:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_16:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_16:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_16:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_17:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_17:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_17:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_18:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_18:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_18:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_19:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_19:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_19:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_20:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_20:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_20:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_21:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_21:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_21:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_22:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_22:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_22:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-29_23:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-29_23:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-29_23:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_00:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_00:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_00:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_01:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_01:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_01:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_02:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_02:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_02:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_03:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_03:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_03:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_04:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_04:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_04:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_05:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_05:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_05:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_06:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_06:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_06:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_07:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_07:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_07:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_08:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_08:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_08:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_09:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_09:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_09:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_10:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_10:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_10:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_11:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_11:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_11:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_12:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_12:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_12:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_13:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_13:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_13:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_14:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_14:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_14:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_15:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_15:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_15:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_16:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_16:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_16:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_17:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_17:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_17:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_18:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_18:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_18:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_19:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_19:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_19:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_20:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_20:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_20:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_21:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_21:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_21:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_22:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_22:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_22:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-30_23:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-30_23:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-30_23:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_00:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_00:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_00:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_01:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_01:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_01:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_02:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_02:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_02:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_03:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_03:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_03:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_04:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_04:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_04:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_05:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_05:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_05:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_06:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_06:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_06:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_07:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_07:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_07:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_08:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_08:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_08:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_09:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_09:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_09:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_10:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_10:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_10:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_11:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_11:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_11:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_12:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_12:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_12:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_13:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_13:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_13:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_14:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_14:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_14:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_15:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_15:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_15:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_16:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_16:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_16:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_17:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_17:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_17:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_18:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_18:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_18:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_19:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_19:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_19:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_20:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_20:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_20:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_21:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_21:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_21:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_22:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_22:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_22:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-08-31_23:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-08-31_23:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-08-31_23:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_00:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_00:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_00:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_01:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_01:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_01:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_02:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_02:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_02:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_03:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_03:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_03:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_04:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_04:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_04:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_05:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_05:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_05:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_06:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_06:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_06:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_07:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_07:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_07:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_08:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_08:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_08:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_09:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_09:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_09:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_10:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_10:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_10:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_11:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_11:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_11:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_12:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_12:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_12:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_13:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_13:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_13:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_14:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_14:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_14:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_15:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_15:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_15:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_16:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_16:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_16:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_17:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_17:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_17:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_18:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_18:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_18:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_19:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_19:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_19:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_20:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_20:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_20:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_21:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_21:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_21:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_22:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_22:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_22:00:00.png
+      - 6_visualize/tmp/gif_frame_a_2017-09-01_23:00:00.png
+      - 6_visualize/tmp/gif_frame_b_2017-09-01_23:00:00.png
+      - 6_visualize/tmp/gif_frame_c_2017-09-01_23:00:00.png

--- a/6_visualize.yml
+++ b/6_visualize.yml
@@ -43,23 +43,19 @@ targets:
   # tmp=temporary folder for holding files to only be created on 1 computer.
   # out=folder to hold .ind and data files corresponding to shared cache or everybody's local build.
   # log=folder for the few indicator files that don't correspond to a data file.
-  6_visualize/tmp:
-    command: dir.create(target_name, recursive=I(TRUE), showWarnings=I(FALSE))
-  6_visualize/log:
-    command: dir.create(target_name, recursive=I(TRUE), showWarnings=I(FALSE))
   visualize_folders:
     command: list(
-      tmp='6_visualize/tmp',
-      log='6_visualize/log')
+      tmp=I('6_visualize/tmp'),
+      log=I('6_visualize/log'))
 
   gif_tasks:
     command: create_gif_tasks(
       timestep_ind = '2_process/out/timesteps.rds.ind',
       folders = visualize_folders,
-      view_ind = '5_vizprep/out/view_fun.rds.ind',
-      basemap_ind = '5_vizprep/out/basemap_fun.rds.ind',
-      storm_line_ind = '5_vizprep/out/storm_line_fun.rds.ind',
-      cfg = storm_frame_config)
+      view_ind = '6_vizprep/out/view_fun.rds.ind',
+      basemap_ind = '6_vizprep/out/basemap_fun.rds.ind',
+      storm_line_ind = '6_vizprep/out/storm_line_fun.rds.ind',
+      storm_cfg = storm_frame_config)
 
   6_gif_tasks.yml:
     command: create_gif_makefile(

--- a/6_visualize/log/placeholder
+++ b/6_visualize/log/placeholder
@@ -1,0 +1,1 @@
+placeholder

--- a/6_visualize/src/create_gif_tasks.R
+++ b/6_visualize/src/create_gif_tasks.R
@@ -2,7 +2,7 @@
 
 
 
-create_gif_tasks <- function(timestep_ind, folders, view_ind, basemap_ind, storm_line_ind, cfg){
+create_gif_tasks <- function(timestep_ind, folders, view_ind, basemap_ind, storm_line_ind, storm_cfg){
 
   timestep <- readRDS(sc_retrieve(timestep_ind))
 
@@ -11,7 +11,7 @@ create_gif_tasks <- function(timestep_ind, folders, view_ind, basemap_ind, storm
   tasks <- tidyr::crossing(timestep, cfgs) %>%
     unite(task_name, cfgs, timestep, sep = '_', remove = F) %>%
     mutate(task_name = gsub(' ', '_', task_name),
-           date_hour = strftime(timestep, format = '%Y%m%d_%H', tz = 'UTC'))
+           date_hour = strftime(timestep, format = '%Y%m%d-%H', tz = 'UTC'))
 
   # function to sprintf a bunch of key-value (string-variableVector) pairs, then
   # paste them together with a good separator for constructing remake recipes
@@ -35,13 +35,13 @@ create_gif_tasks <- function(timestep_ind, folders, view_ind, basemap_ind, storm
       psprintf(
         "create_storm_frame(",
         "png_file=target_name",
-        "config='%s',"=cfg,
+        "config=storm_frame_config,",
         "'%s',"=view_ind,
         "'%s',"=basemap_ind,
         "'%s'"=storm_line_ind,
-        "5_vizprep/out/storm_point_%s.rds.ind,"=cur_task$date_hour,
-        "5_vizprep/out/precip_raster_%s.rds.ind,"=cur_task$date_hour,
-        "5_vizprep/out/streamdata_%s.rds.ind,"=cur_task$date_hour,
+        "'6_vizprep/out/storm_point_[%s].rds.ind',"=cur_task$date_hour,
+        "'6_vizprep/out/precip_raster_[%s].rds.ind',"=cur_task$date_hour,
+        "'6_vizprep/out/streamdata_[%s].rds.ind')"=cur_task$date_hour,
         sep="\n      ")
     }
   )

--- a/6_visualize/tmp/placeholder
+++ b/6_visualize/tmp/placeholder
@@ -1,0 +1,1 @@
+placeholder

--- a/6_vizprep.yml
+++ b/6_vizprep.yml
@@ -11,6 +11,10 @@ file_extensions:
 
 sources:
   - 6_vizprep/src/prep_plot_funs.R
+  - 6_vizprep/src/prep_basemap_fun.R
+  - 6_vizprep/src/prep_view_fun.R
+  - 6_vizprep/src/prep_storm_point_fun.R
+  - 6_vizprep/src/prep_storm_line_fun.R
 
 targets:
 

--- a/6_vizprep/src/prep_basemap_fun.R
+++ b/6_vizprep/src/prep_basemap_fun.R
@@ -1,0 +1,18 @@
+prep_basemap_fun <- function(ind_file, focus_geoms_ind, secondary_geoms_ind = NULL, detail_geoms_ind = NULL){
+
+  plot_fun <- function(){
+    if (!is.null(secondary_geoms_ind)){
+      secondary_geoms <- readRDS(sc_retrieve(secondary_geoms_ind))
+      plot(secondary_geoms, add = TRUE, lwd = 0.3, col = 'grey80') # should style args be in a config?
+    }
+
+    if (!is.null(detail_geoms_ind)){
+      detail_geoms <- readRDS(sc_retrieve(detail_geoms_ind))
+      plot(detail_geoms, add = TRUE, lwd = 0.3, col = NA, border = 'grey95') # should style args be in a config?
+    }
+
+    focus_geoms <- readRDS(sc_retrieve(focus_geoms_ind))
+    plot(focus_geoms, add = TRUE, col = NA, border = 'grey40')
+  }
+  write_put_fun(plot_fun, ind_file)
+}

--- a/6_vizprep/src/prep_plot_funs.R
+++ b/6_vizprep/src/prep_plot_funs.R
@@ -1,31 +1,4 @@
 
-prep_basemap_fun <- function(ind_file, focus_geoms_ind, secondary_geoms_ind = NULL, detail_geoms_ind = NULL){
-
-  plot_fun <- function(){
-    if (!is.null(secondary_geoms_ind)){
-      secondary_geoms <- readRDS(sc_retrieve(secondary_geoms_ind))
-      plot(secondary_geoms, add = TRUE, lwd = 0.3, col = 'grey80') # should style args be in a config?
-    }
-
-    if (!is.null(detail_geoms_ind)){
-      detail_geoms <- readRDS(sc_retrieve(detail_geoms_ind))
-      plot(detail_geoms, add = TRUE, lwd = 0.3, col = NA, border = 'grey95') # should style args be in a config?
-    }
-
-    focus_geoms <- readRDS(sc_retrieve(focus_geoms_ind))
-    plot(focus_geoms, add = TRUE, col = NA, border = 'grey40')
-  }
-  write_put_fun(plot_fun, ind_file)
-}
-
-prep_view_fun <- function(ind_file, view_polygon){
-  plot_fun <- function(){
-    par(omi = c(0,0,0,0), mai = c(0,0,0,0))
-    plot(view_polygon, col = NA, border = NA, xaxs = 'i', yaxs = 'i')
-  }
-  write_put_fun(plot_fun, ind_file)
-}
-
 POSIX_from_filename <- function(filename){
   date_char <- gsub("\\[|\\]", "", regmatches(filename, gregexpr("\\[.*?\\]", filename))[[1]][1])
   posix_out <- as.POSIXct(date_char, format = '%Y%m%d-%H', tz = "UTC")
@@ -35,25 +8,6 @@ POSIX_from_filename <- function(filename){
   return(posix_out)
 }
 
-prep_storm_point_fun <- function(ind_file, storm_points_ind_file){
-  storm_points_sf <- readRDS(sc_retrieve(storm_points_ind_file))
-  # parse date from ind_file
-  this_DateTime <- POSIX_from_filename(ind_file)
-  this_dot <- filter(storm_points_sf, DateTime == this_DateTime)
-  plot_fun <- function(){
-    plot(this_dot, add = TRUE, col = 'red', pch = 20, cex = 2) # should style args be in a config?
-  }
-  write_put_fun(plot_fun, ind_file)
-}
-
-prep_storm_line_fun <- function(ind_file, storm_line_ind_file){
-  storm_line_sf <- readRDS(sc_retrieve(storm_line_ind_file))
-
-  plot_fun <- function(){
-    plot(storm_line_sf, add = TRUE, col = 'black', lwd = 2)
-  }
-  write_put_fun(plot_fun, ind_file)
-}
 write_put_fun <- function(plot_fun, ind_file){
   data_file <- as_data_file(ind_file)
   saveRDS(plot_fun, data_file)

--- a/6_vizprep/src/prep_storm_line_fun.R
+++ b/6_vizprep/src/prep_storm_line_fun.R
@@ -1,0 +1,9 @@
+
+prep_storm_line_fun <- function(ind_file, storm_line_ind_file){
+  storm_line_sf <- readRDS(sc_retrieve(storm_line_ind_file))
+
+  plot_fun <- function(){
+    plot(storm_line_sf, add = TRUE, col = 'black', lwd = 2)
+  }
+  write_put_fun(plot_fun, ind_file)
+}

--- a/6_vizprep/src/prep_storm_point_fun.R
+++ b/6_vizprep/src/prep_storm_point_fun.R
@@ -1,0 +1,11 @@
+
+prep_storm_point_fun <- function(ind_file, storm_points_ind_file){
+  storm_points_sf <- readRDS(sc_retrieve(storm_points_ind_file))
+  # parse date from ind_file
+  this_DateTime <- POSIX_from_filename(ind_file)
+  this_dot <- filter(storm_points_sf, DateTime == this_DateTime)
+  plot_fun <- function(){
+    plot(this_dot, add = TRUE, col = 'red', pch = 20, cex = 2) # should style args be in a config?
+  }
+  write_put_fun(plot_fun, ind_file)
+}

--- a/6_vizprep/src/prep_view_fun.R
+++ b/6_vizprep/src/prep_view_fun.R
@@ -1,0 +1,8 @@
+
+prep_view_fun <- function(ind_file, view_polygon){
+  plot_fun <- function(){
+    par(omi = c(0,0,0,0), mai = c(0,0,0,0))
+    plot(view_polygon, col = NA, border = NA, xaxs = 'i', yaxs = 'i')
+  }
+  write_put_fun(plot_fun, ind_file)
+}


### PR DESCRIPTION
Updating gif_tasks_table based on some comments from #37, and splitting `prep_plot_funs.R` into individual functions. 

This creates a new yaml called `6_gif_task.yml` which has targets for all the gif frames. 