### PR TITLE
shrink the closure from prep_precip_fun

### DIFF
--- a/6_visualize/src/prep_precip_fun.R
+++ b/6_visualize/src/prep_precip_fun.R
@@ -16,8 +16,13 @@ prep_precip_fun <- function(precip_rasters, precip_bins, timestep){
                     rgb(x[1], x[2], x[3], x[4],
                         maxColorValue = 255)})
 
+  one_precip_raster <- precip_rasters[[timestep]]
+
+  # clean up the environment to keep the closure small
+  rm(precip_rasters, precip_bins, rgb_ramp, timestep)
+
   plot_fun <- function(){
-    plot(precip_rasters[[timestep]], add = TRUE, breaks = breaks, col = colors, legend = FALSE)
+    plot(one_precip_raster, add = TRUE, breaks = breaks, col = colors, legend = FALSE)
   }
   return(plot_fun)
 }


### PR DESCRIPTION
ran this code before and after editing prep_precip_fun:
```r
precip_fun <- scmake('precip_raster_a_20170825_02', '6_storm_gif_tasks.yml')
pryr::object_size(precip_fun)
```

before the edits, result was `804 MB`. after the edits, result is `5.31 MB`
still not tiny, but maybe as small as it can be?

the entire collection of precip_rasters is `802 MB`:
```r
> pryr::object_size(precip_rasters)
802 MB
```
and there are 191 rasters, so each one should have size `4.2 MB`