### PR TITLE
fix bug in river simplification fixes #73

### DIFF
--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -130,13 +130,13 @@ targets:
     command: gd_get('1_fetch/out/precip_values.rds.ind')
 
   # -- get river geometry --
-  fetch_simplification_tolerance_m:
-    command: viz_config[I('fetch_simplification_tolerance_m')]
+  fetch_streamorder:
+    command: viz_config[I('fetch_streamorder')]
 
   1_fetch/out/major_river_geometry.rds.ind:
     command: fetch_major_river_geoms(ind_fil=target_name,
                                view_polygon=view_polygon,
-                               pre_simplify_m=fetch_simplification_tolerance_m)
+                               fetch_streamorder=fetch_streamorder)
   1_fetch/out/major_river_geometry.rds:
     command: gd_get('1_fetch/out/major_river_geometry.rds.ind')
 

--- a/1_fetch/out/major_river_geometry.rds.ind
+++ b/1_fetch/out/major_river_geometry.rds.ind
@@ -1,2 +1,2 @@
-hash: 1cebc0f9159f74eeddcd429aab4d5ee4
+hash: 14c4c1d95179aeaea55722933c41fc62
 

--- a/1_fetch/src/fetch_river_geometry.R
+++ b/1_fetch/src/fetch_river_geometry.R
@@ -1,22 +1,18 @@
-fetch_major_river_geoms <- function(ind_file, view_polygon, pre_simplify_m) {
+fetch_major_river_geoms <- function(ind_file, view_polygon, fetch_streamorder) {
 
   bbox <- st_bbox(st_transform(view_polygon, 4326))
 
   postURL <- "https://cida.usgs.gov/nwc/geoserver/nhdplus/ows"
 
-  # streamorder <- 4
-  # Leaving this here in case we want to add a property filter back
-  # '<ogc:And>',
-  # '<ogc:PropertyIsGreaterThan>',
-  # '<ogc:PropertyName>streamorde</ogc:PropertyName>',
-  # '<ogc:Literal>',streamorder,'</ogc:Literal>',
-  # '</ogc:PropertyIsGreaterThan>',
-  # ...
-  # '</ogc:And>',
   filterXML <- paste0('<?xml version="1.0"?>',
                       '<wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" service="WFS" version="1.1.0" outputFormat="application/json" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">',
                       '<wfs:Query xmlns:feature="http://gov.usgs.cida/nhdplus" typeName="feature:nhdflowline_network" srsName="EPSG:4326">',
                       '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">',
+                      '<ogc:And>',
+                      '<ogc:PropertyIsGreaterThan>',
+                      '<ogc:PropertyName>streamorde</ogc:PropertyName>',
+                      '<ogc:Literal>',fetch_streamorder,'</ogc:Literal>',
+                      '</ogc:PropertyIsGreaterThan>',
                       '<ogc:BBOX>',
                       '<ogc:PropertyName>the_geom</ogc:PropertyName>',
                       '<gml:Envelope>',
@@ -24,6 +20,7 @@ fetch_major_river_geoms <- function(ind_file, view_polygon, pre_simplify_m) {
                       '<gml:upperCorner>',bbox[4]," ",bbox[3],'</gml:upperCorner>',
                       '</gml:Envelope>',
                       '</ogc:BBOX>',
+                      '</ogc:And>',
                       '</ogc:Filter>',
                       '</wfs:Query>',
                       '</wfs:GetFeature>')
@@ -31,8 +28,7 @@ fetch_major_river_geoms <- function(ind_file, view_polygon, pre_simplify_m) {
   out <- httr::POST(postURL, body = filterXML)
 
   sf_major_rivers <- read_sf(rawToChar(out$content)) %>%
-    st_transform(st_crs(view_polygon)) %>%
-    st_simplify(dTolerance = pre_simplify_m[[1]])
+    st_transform(st_crs(view_polygon))
 
   data_file <- as_data_file(ind_file)
   saveRDS(sf_major_rivers, data_file)

--- a/2_process/out/river_geoms.rds.ind
+++ b/2_process/out/river_geoms.rds.ind
@@ -1,2 +1,2 @@
-hash: dbe69f445abfcea736696bb8a26cb3fe
+hash: c711ddd2502853b45be13a55263456be
 

--- a/2_process/src/process_river_geoms.R
+++ b/2_process/src/process_river_geoms.R
@@ -12,10 +12,10 @@ process_river_geoms <- function(ind_file,
 
   outlets <- filter(sf_major_rivers,
                     (terminalfl == 1 &
-                       totdasqkm > coastal_threshold_sqkm))$levelpathi
+                       divdasqkm > coastal_threshold_sqkm))$levelpathi
 
   inland <- filter(sf_major_rivers,
-                   totdasqkm > inland_threshold_sqkm)$levelpathi
+                   divdasqkm > inland_threshold_sqkm)$levelpathi
 
   sf_major_rivers <- filter(sf_major_rivers,
                             levelpathi %in% c(outlets, inland)) %>%

--- a/build/status/MV9mZXRjaC9vdXQvbWFqb3Jfcml2ZXJfZ2VvbWV0cnkucmRzLmluZA.yml
+++ b/build/status/MV9mZXRjaC9vdXQvbWFqb3Jfcml2ZXJfZ2VvbWV0cnkucmRzLmluZA.yml
@@ -1,13 +1,13 @@
 version: 0.3.0
 name: 1_fetch/out/major_river_geometry.rds.ind
 type: file
-hash: 773b9ef177c5538907d07be4a9e5a130
-time: 2018-07-12 17:25:41 UTC
+hash: ebaed721ec4ba7cd720fe8d0476a3cd4
+time: 2018-07-13 16:01:33 UTC
 depends:
   view_polygon: 7ac3d28632d1dfbad8fd1b6044d4485a
-  fetch_simplification_tolerance_m: 7c7d9aa6a1103fbc5a31b391b2661f19
+  fetch_streamorder: 06a8d98990c2c3bbe1f02e8a82b72727
 fixed: 5b890ba647d25b5e57a59506fe05c249
 code:
   functions:
-    fetch_major_river_geoms: 81dbe5fcf181dfe9390a8aab0cc86bf6
+    fetch_major_river_geoms: 9fe55369755b64ef3b0a4caf9dc8de9e
 

--- a/build/status/Ml9wcm9jZXNzL291dC9yaXZlcl9nZW9tcy5yZHMuaW5k.yml
+++ b/build/status/Ml9wcm9jZXNzL291dC9yaXZlcl9nZW9tcy5yZHMuaW5k.yml
@@ -1,14 +1,14 @@
 version: 0.3.0
 name: 2_process/out/river_geoms.rds.ind
 type: file
-hash: a887411a35e0a44230f06140e2b5e703
-time: 2018-07-12 20:19:38 UTC
+hash: ba169ef6a88d49e5a6585739b20d673a
+time: 2018-07-13 16:07:42 UTC
 depends:
-  1_fetch/out/major_river_geometry.rds.ind: 773b9ef177c5538907d07be4a9e5a130
+  1_fetch/out/major_river_geometry.rds.ind: ebaed721ec4ba7cd720fe8d0476a3cd4
   1_fetch/out/gage_river_geometry.rds.ind: 7c74d626c8a853c45e45d18028d3ef97
-  river_geom_config: f4a45e6f15c5e08e86de73eb95bf0e3c
+  river_geom_config: 1df4f9645eae56f7a9c6aadcbde6f602
 fixed: d548f0f8fe0d75d923bfc74462f3bae0
 code:
   functions:
-    process_river_geoms: d1bd4cdce851e066f0a8cb8627574a2b
+    process_river_geoms: 626a4aa9a49f1b11ba8218ba40671f73
 

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -31,13 +31,8 @@ secondary_geoms:
     database: "mapdata::worldHires"
     regions: "Mexico"
 
-# Change will cause refetch of entire nhdplus for view_polygon
-# This is input to sf::st_simplify on the NHDPlus flowlines that
-# are downloaded by the fetcher that uses it. Reduce it if you
-# are going to reduce simplification_tolerance_m below it.
-# a value of about 30m will have no affect on the data anything
-# greater will remove increasingly more curvature from lines.
-fetch_simplification_tolerance_m: 500
+# Only streamorders greater than this will be fetched.
+fetch_streamorder: 2
 
 # Changes only affect river geom process step.
 # Coastal threshold controls the drainage area used to limit
@@ -46,4 +41,4 @@ fetch_simplification_tolerance_m: 500
 # that terminate into other flowlines.
 coastal_threshold_sqkm: 1000
 inland_threshold_sqkm: 40000
-simplification_tolerance_m: 5000
+simplification_tolerance_m: 1000


### PR DESCRIPTION
![gif_frame_a_20170827_14](https://user-images.githubusercontent.com/1492803/42701927-855b0bf2-868d-11e8-9a07-8788c8df485d.png)
Also adjusted the download to pull down less data and changed the simplification tolerance to 1000m. I think this is looking pretty good.
This is what the rivers looked like before:
![gif_frame_a_20170901_23](https://user-images.githubusercontent.com/1492803/42702016-c7e8ffba-868d-11e8-96f9-de4ec9b0d3dc.png)
