### PR TITLE
restore the sf-ness of normalized streamdata

### DIFF
--- a/1_fetch/out/streamdata.rds.ind
+++ b/1_fetch/out/streamdata.rds.ind
@@ -1,2 +1,2 @@
-hash: 14fb1bcd8c28e736a59a8ab77a2c8441
+hash: 1da2698dba49bb03df40b23c51a061d5
 

--- a/2_process/out/normalized_streamdata.rds.ind
+++ b/2_process/out/normalized_streamdata.rds.ind
@@ -1,2 +1,2 @@
-hash: 35fcda278c181ed517f7bae9137e589f
+hash: b9c4d56e45dcf1a97532209ba43f1132
 

--- a/2_process/src/normalize_streamdata.R
+++ b/2_process/src/normalize_streamdata.R
@@ -4,7 +4,7 @@ normalize_streamdata <- function(ind_file, raw_ind_file, sites_ind_file){
 
   streamdata <- readRDS(sc_retrieve(raw_ind_file)) # NWIS raw data
   storm_sites <- readRDS(sc_retrieve(sites_ind_file))
-  storm_data <- left_join(streamdata, storm_sites)
+  storm_data <- left_join(streamdata, storm_sites, by='site_no')
 
   # we assume "normalized" stage is between 0 and 1
   # if that changes, see 6_visualize/src/prep_spark_line_fun.R
@@ -16,8 +16,9 @@ normalize_streamdata <- function(ind_file, raw_ind_file, sites_ind_file){
     mutate(stage_normalized = (stage - min(stage, na.rm = T)) / (max(stage, na.rm = T) - min(stage, na.rm = T))) %>%
     mutate(flood_stage_normalized = (as.numeric(flood_stage) - min(stage, na.rm = T)) / (max(stage, na.rm = T) - min(stage, na.rm = T))) %>%
     ungroup()
+  norm_stream_sf <- sf::st_as_sf(norm_stream)
 
   data_file <- as_data_file(ind_file)
-  saveRDS(norm_stream, data_file)
+  saveRDS(norm_stream_sf, data_file)
   gd_put(ind_file, data_file)
 }

--- a/build/status/MV9mZXRjaC9vdXQvYWxsX3NpdGVzLnJkcy5pbmQ.yml
+++ b/build/status/MV9mZXRjaC9vdXQvYWxsX3NpdGVzLnJkcy5pbmQ.yml
@@ -2,10 +2,10 @@ version: 0.3.0
 name: 1_fetch/out/all_sites.rds.ind
 type: file
 hash: 22149c5d481d0c6f4014e69cb8317d39
-time: 2018-07-16 15:25:03 UTC
+time: 2018-07-19 20:35:33 UTC
 depends:
   state_cds: 51daf5668781ff87d8656d10e5c8d621
-  dates: 289b0e4fc141107257b7fcfa08c5adc5
+  dates: 5a6317d91a1fb110e6a154ea8c391fec
   stream_params: 089aebea962cdd0eb862e4ccd23302bd
 fixed: 7a8a5e2410f97f8c9bc1ebe4fbc32d84
 code:

--- a/build/status/MV9mZXRjaC9vdXQvc3RyZWFtZGF0YS5yZHMuaW5k.yml
+++ b/build/status/MV9mZXRjaC9vdXQvc3RyZWFtZGF0YS5yZHMuaW5k.yml
@@ -1,13 +1,13 @@
 version: 0.3.0
 name: 1_fetch/out/streamdata.rds.ind
 type: file
-hash: 602d028e08c12cb6808068f929354bb4
-time: 2018-07-13 20:57:29 UTC
+hash: 846892726e245ac965583c7a938c9dcc
+time: 2018-07-19 20:36:17 UTC
 depends:
   2_process/out/storm_sites.rds.ind: 607ee3a73a02b812c0f24842f158e47d
   dates: 5a6317d91a1fb110e6a154ea8c391fec
   stream_params: 089aebea962cdd0eb862e4ccd23302bd
-  lib/cfg/gd_config.yml: 48b9a0e46bf23a8fdbf6ed9ee984a5f9
+  lib/cfg/gd_config.yml: 8022d0274137821a4b66cf534320163a
 fixed: 730fe0a4966514866300139c5ad8f739
 code:
   functions:

--- a/build/status/Ml9wcm9jZXNzL291dC9ub3JtYWxpemVkX3N0cmVhbWRhdGEucmRzLmluZA.yml
+++ b/build/status/Ml9wcm9jZXNzL291dC9ub3JtYWxpemVkX3N0cmVhbWRhdGEucmRzLmluZA.yml
@@ -1,13 +1,13 @@
 version: 0.3.0
 name: 2_process/out/normalized_streamdata.rds.ind
 type: file
-hash: 6b461152f50df5235264038342e2c302
-time: 2018-07-13 21:23:24 UTC
+hash: 9a9f34f323fc85e9b43ccf47d39a938f
+time: 2018-07-19 21:09:00 UTC
 depends:
-  1_fetch/out/streamdata.rds.ind: 602d028e08c12cb6808068f929354bb4
+  1_fetch/out/streamdata.rds.ind: 846892726e245ac965583c7a938c9dcc
   2_process/out/storm_sites.rds.ind: 607ee3a73a02b812c0f24842f158e47d
 fixed: e8220ed7526ce5e94f7e6256176d60db
 code:
   functions:
-    normalize_streamdata: 2637ccc90b9bf34407a4e87e32b28dce
+    normalize_streamdata: 87270436c8e81f3b4f000afc756cbb45
 


### PR DESCRIPTION
Bug fix - I was getting an error in the `storm_sites_fun` at this line:
```
plot(sf::st_geometry(norm_data_sites$geometry), add = TRUE,
         pch = 21, bg = gage_col_config$gage_norm_col, col = NA)
```
where the error was something about st_geometry not wanting its argument to be NULL, which seemed to be because `norm_data_sites` wasn't an sf object (even though it did have a geometry column). This change seems to fix the problem.