### PR TITLE
get the stage IV .nc file local

### DIFF
--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -12,6 +12,7 @@ packages:
   - maps
   - ncdf4
   - arrayhelpers
+  - geoknife
   - dplyr
   - xml2
   - jsonlite
@@ -24,6 +25,7 @@ sources:
   - 1_fetch/src/fetch_storm_track.R
   - 1_fetch/src/map_utils.R
   - 1_fetch/src/fetch_sites.R
+  - 1_fetch/src/fetch_precip_nc.R
   - 1_fetch/src/fetch_precip_spatial.R
   - 1_fetch/src/fetch_precip_values.R
   - 1_fetch/src/fetch_river_geometry.R
@@ -120,6 +122,12 @@ targets:
     command: gd_get('1_fetch/out/streamdata.rds.ind')
 
   # -- get precip --
+  1_fetch/out/precip_cube.nc.ind:
+    command: fetch_precip_nc(ind_file=target_name,
+                                view_polygon = view_polygon, times = dates)
+  1_fetch/out/precip_cube.nc:
+    command: gd_get('1_fetch/out/precip_cube.nc.ind')
+
   1_fetch/out/precip_spatial.rds.ind:
     command: fetch_precip_spatial(ind_file=target_name,
                                 view_polygon = view_polygon)

--- a/1_fetch/src/fetch_precip_nc.R
+++ b/1_fetch/src/fetch_precip_nc.R
@@ -1,0 +1,34 @@
+#' @param ind_file scipiper indicator file
+#' @param view_polygon from the view_polygon target
+#' @param times the start and end time of the request
+fetch_precip_nc <- function(ind_file, view_polygon, times) {
+  fabric <- webdata(url = 'https://cida.usgs.gov/thredds/dodsC/stageiv_combined',
+                    variables = "Total_precipitation_surface_1_Hour_Accumulation",
+                    times = as.POSIXct(c(times$start,times$end), tz = 'UTC'))
+
+  knife <- webprocess(algorithm = list('OPeNDAP Subset' = "gov.usgs.cida.gdp.wps.algorithm.FeatureCoverageOPeNDAPIntersectionAlgorithm"),
+                      REQUIRE_FULL_COVERAGE = FALSE, wait = TRUE, OUTPUT_TYPE = 'netcdf')
+
+  crs <- st_crs(view_polygon)
+  bbox <- st_bbox(view_polygon)
+
+  as.stencil_pt <- function(box1, box2, col_name){
+    st_sf(st_sfc(st_point(c(bbox[[box1]], bbox[[box2]]), dim = "XY")), crs = crs) %>%
+      st_transform(crs = "+init=epsg:4326") %>%
+      st_coordinates() %>% as.vector() %>% data.frame(x = .) %>% setNames(col_name)
+  }
+
+  stencil_pts <- as.stencil_pt('xmin', 'ymax', 'up_left')
+
+  stencil_pts <- as.stencil_pt('xmax', 'ymax', 'up_right') %>% cbind(stencil_pts)
+
+  stencil_pts <- as.stencil_pt('xmax', 'ymin', 'low_right') %>% cbind(stencil_pts)
+
+  stencil_pts <- as.stencil_pt('xmin', 'ymin', 'low_left') %>% cbind(stencil_pts)
+
+  job <- geoknife(stencil = stencil_pts, fabric = fabric, knife = knife)
+  data_file <- as_data_file(ind_file)
+  download(.Object = job, destination = data_file, overwrite = TRUE)
+
+  gd_put(remote_ind=ind_file, local_source=data_file, mock_get='none')
+}


### PR DESCRIPTION
This is a partial implementation of #102 

The GDP subset is quick, but the download of the result is slow (for Harvey, this is ~0.5GB). If we wanted to go this route, I would suggest including some processing at the tail end of this fetch to shrink the target. 

Alternatively, Alison is exploring docker at the same time, since linux works w/ the nc_open on URLs.