### PR TITLE
keep UTC when constructing dateseq for precip fetch

### DIFF
--- a/1_fetch/src/fetch_precip_nc.R
+++ b/1_fetch/src/fetch_precip_nc.R
@@ -20,7 +20,7 @@ fetch_precip_data <- function(ind_file, view_polygon, times) {
   stencil_pts <- as.stencil_pt('xmin', 'ymin', 'low_left') %>% cbind(stencil_pts)
 
   # break times into chunks to avoid WAF rejections of queries that are "too big"
-  try_formats = c("%Y-%m-%d %H:%M:%OS", "%Y/%m/%d %H:%M:%OS", "%Y-%m-%d %H:%M", "%Y/%m/%d %H:%M", "%Y-%m-%d", "%Y/%m/%d")
+  try_formats <- c("%Y-%m-%d %H:%M:%OS", "%Y/%m/%d %H:%M:%OS", "%Y-%m-%d %H:%M", "%Y/%m/%d %H:%M", "%Y-%m-%d", "%Y/%m/%d")
   dateformat <- try_formats[sapply(try_formats, function(fmt) all(!is.na(as.POSIXct(unlist(times), format=fmt))))]
   dateseq <- as.POSIXct(unique(c(
     format(seq(as.POSIXct(times$start, tz='UTC'), as.POSIXct(times$end, tz='UTC'), by=as.difftime(3, units='days')), dateformat),
@@ -29,10 +29,15 @@ fetch_precip_data <- function(ind_file, view_polygon, times) {
   precip_data_list <- lapply(seq_len(length(dateseq)-1), function(i) {
     message(sprintf("pulling precip for %s to %s", dateseq[i], dateseq[i+1]))
     # define the fabric, subset by time
+    times <- if(i == length(dateseq)-1) {
+      dateseq[i:(i+1)]
+    } else {
+      c(dateseq[i], dateseq[i+1]-as.difftime(1, units='mins'))
+    }
     fabric <- webdata(
       url = 'https://cida.usgs.gov/thredds/dodsC/stageiv_combined',
       variables = "Total_precipitation_surface_1_Hour_Accumulation",
-      times = c(dateseq[i], dateseq[i+1]-as.difftime(1, units='mins')))
+      times = times)
 
     # run the job and retrieve the results
     job <- geoknife(stencil = stencil_pts, fabric = fabric, knife = knife)

--- a/1_fetch/src/fetch_precip_nc.R
+++ b/1_fetch/src/fetch_precip_nc.R
@@ -19,7 +19,10 @@ fetch_precip_data <- function(ind_file, view_polygon, times) {
   stencil_pts <- as.stencil_pt('xmax', 'ymin', 'low_right') %>% cbind(stencil_pts)
   stencil_pts <- as.stencil_pt('xmin', 'ymin', 'low_left') %>% cbind(stencil_pts)
 
-  # break times into chunks to avoid WAF rejections of queries that are "too big"
+  # break times into chunks to avoid WAF rejections of queries that are "too
+  # big". use dateformat and some string-POSIXct back and forth to retain the
+  # UTC timezone despite calls to c(), which always switches you back into
+  # user's local timezone
   try_formats <- c("%Y-%m-%d %H:%M:%OS", "%Y/%m/%d %H:%M:%OS", "%Y-%m-%d %H:%M", "%Y/%m/%d %H:%M", "%Y-%m-%d", "%Y/%m/%d")
   dateformat <- try_formats[sapply(try_formats, function(fmt) all(!is.na(as.POSIXct(unlist(times), format=fmt))))]
   dateseq <- as.POSIXct(unique(c(
@@ -29,15 +32,18 @@ fetch_precip_data <- function(ind_file, view_polygon, times) {
   precip_data_list <- lapply(seq_len(length(dateseq)-1), function(i) {
     message(sprintf("pulling precip for %s to %s", dateseq[i], dateseq[i+1]))
     # define the fabric, subset by time
-    times <- if(i == length(dateseq)-1) {
+    times_subset <- if(i == length(dateseq)-1) {
       dateseq[i:(i+1)]
     } else {
-      c(dateseq[i], dateseq[i+1]-as.difftime(1, units='mins'))
+      as.POSIXct(
+        c(format(dateseq[i], dateformat),
+          format(dateseq[i+1]-as.difftime(1, units='mins'), dateformat)),
+        tz='UTC')
     }
     fabric <- webdata(
       url = 'https://cida.usgs.gov/thredds/dodsC/stageiv_combined',
       variables = "Total_precipitation_surface_1_Hour_Accumulation",
-      times = times)
+      times = times_subset)
 
     # run the job and retrieve the results
     job <- geoknife(stencil = stencil_pts, fabric = fabric, knife = knife)


### PR DESCRIPTION
I think this should do it. Haven't tested yet, though. Fixing the issue that the c() in the old code was causing dateseq to be in the user's local time rather than in UTC, which meant we were failing to catch some precip timestamps at the end of the date range. Will test next, but since it takes tens of minutes, figured I could also share.