### PR TITLE
a couple tiny fixes from building Gordon

### DIFF
--- a/1_fetch/src/fetch_precip_nc.R
+++ b/1_fetch/src/fetch_precip_nc.R
@@ -36,8 +36,8 @@ fetch_precip_data <- function(ind_file, view_polygon, times) {
       dateseq[i:(i+1)]
     } else {
       as.POSIXct(
-        c(format(dateseq[i], dateformat),
-          format(dateseq[i+1]-as.difftime(1, units='mins'), dateformat)),
+        c(format(dateseq[i], "%Y-%m-%d %H:%M:%OS"),
+          format(dateseq[i+1]-as.difftime(1, units='mins'), "%Y-%m-%d %H:%M:%OS")),
         tz='UTC')
     }
     fabric <- webdata(

--- a/6_visualize/src/prep_precip_fun.R
+++ b/6_visualize/src/prep_precip_fun.R
@@ -4,7 +4,7 @@ prep_precip_fun <- function(precip_rasters, precip_bins, timestep){
   breaks <- unique(c(precip_bins$left_break,
                      precip_bins$right_break))
   breaks[which(breaks == Inf)] <- 100000 # Just quiets an error
-  breaks <- c(0, 1, breaks[2:length(breaks)]) # Add a tiny break for alpha
+  breaks <- c(0, 0.001, breaks[2:length(breaks)]) # Add a tiny break for alpha
 
   rgb_ramp <- col2rgb(precip_bins$col, alpha = TRUE)
   rgb_ramp <- cbind(rgb_ramp[,1],rgb_ramp)


### PR DESCRIPTION
Fixed an issue with splitting the time up and then ending up missing some time.

Long explanation:

my time period (2018-09-02 to 2018-09-06) makes `dateseq` a vector with `"2018-09-02 UTC" "2018-09-05 UTC" "2018-09-06 UTC"` (to test use this`dateseq <- structure(c(1535846400, 1536105600, 1536192000), class = c("POSIXct", "POSIXt"), tzone = "UTC")`

so inside the lapply that loops over `seq_len(length(dateseq)-1)`  i is only 1 or 2 in this case
the first time you hit that if-else (i=1), you get these as the start and end dates: `"2018-09-02 UTC" "2018-09-04 UTC"`. The second time (i=2) you get `"2018-09-05 UTC" "2018-09-06 UTC"`, so it skips the actually hours in the day for sep 4

I also ended up using my precip breaks to be 0.5 in Gordon which caused the prep_precip_fun to break. A line fails because it is forcing the breaks to start with `0, 1` and then the sequence becomes `c(0, 1, 0.5, 1, 1.5 ...)`. I wasn't sure why the `c(0, 1,` is needed in front of `breaks[2:length(breaks)]`. The comment says "Add a tiny break for alpha" but I don't get what that means. Neither did @aappling-usgs but we changed the 1 to a `0.001` to address the issue.