### PR TITLE
build snowmelt viz with new dates & handle very large raster files

### DIFF
--- a/2_process.yml
+++ b/2_process.yml
@@ -44,14 +44,15 @@ targets:
     command: viz_config[[I('frame_step')]]
 
   # Takes ~ 5 minutes to run for 28 days
-  2_process/out/snow_raster_interp.nc.ind:
+  2_process/out/snow_raster_interp_files.rds.ind:
     command: interpolate_snow_raster_layers(
       ind_file = target_name,
+      raster_out_str = I("2_process/out/snow_raster_interp_%s.nc"),
       timestep_ind = '2_process/out/timesteps.rds.ind',
       frame_step = timestep,
       fetch_snow_tasks_ind = '1_fetch/log/1_fetch_snow_tasks.ind')
-  2_process/out/snow_raster_interp.nc:
-    command: gd_get('2_process/out/snow_raster_interp.nc.ind')
+  2_process/out/snow_raster_interp_files.rds:
+    command: gd_get('2_process/out/snow_raster_interp_files.rds.ind')
 
   2_process/out/timesteps.rds.ind:
     command: choose_timesteps(target_name, dates = dates)

--- a/2_process/out/snow_raster_interp_files.rds.ind
+++ b/2_process/out/snow_raster_interp_files.rds.ind
@@ -1,0 +1,3 @@
+warning: dry_put=TRUE; not actually pushed
+hash: 67c445f268bef3e5e9714ee5cc3286dd
+

--- a/6_visualize.yml
+++ b/6_visualize.yml
@@ -165,7 +165,7 @@ targets:
     command: c(trial_storm_frames_01, trial_storm_frames_07, trial_storm_frames_13, trial_storm_frames_19)
   storm_gif_tasks_executed:
     command: scmake(
-      target_names = I('6_visualize/log/6_storm_gif_tasks.ind'), 
+      target_names = I('6_storm_gif_tasks'), 
       remake_file = '6_storm_gif_tasks.yml')
 
   # Combine the png files into a video.

--- a/6_visualize/src/create_gif_tasks.R
+++ b/6_visualize/src/create_gif_tasks.R
@@ -147,7 +147,7 @@ create_storm_gif_tasks <- function(timestep_ind, folders, snow_data_yml_name, fr
        cur_task <- dplyr::filter(rename(tasks, tn=task_name), tn==task_name)
        psprintf(
          "prep_snow_fun(",
-         "snow_raster_ind = I('2_process/out/snow_raster_interp.nc.ind'),",
+         "snow_raster_ind = I('2_process/out/snow_raster_interp_files.rds.ind'),",
          "snow_data_yml = I('2_process.yml'),",
          "snow_cfg = snow_cfg,",
          "timestep = I('%s')," = format(cur_task$timestep, "%Y-%m-%d %H:%M:%S"),

--- a/6_visualize/src/prep_snow_fun.R
+++ b/6_visualize/src/prep_snow_fun.R
@@ -6,7 +6,12 @@ prep_snow_fun <- function(snow_raster_ind, snow_data_yml, snow_cfg, timestep, ti
   timesteps_corrected <- timesteps_all[seq(1, by = frame_step, to = length(timesteps_all))] 
   
   band_i <- which(timesteps_corrected == as.POSIXct(timestep, tz="UTC"))
-  snow_raster <- raster::raster(sc_retrieve(snow_raster_ind, snow_data_yml), band=band_i)
+  snow_raster_file_info <- readRDS(sc_retrieve(snow_raster_ind, snow_data_yml))
+  
+  # Raster layer index is different from band_i because we split into multiple files
+  raster_fn <- snow_raster_file_info$file[which(snow_raster_file_info$band == band_i)]
+  raster_layer <- snow_raster_file_info$raster_count[which(snow_raster_file_info$band == band_i)]
+  snow_raster <- raster::raster(raster_fn, band=raster_layer)
   
   # clean up the environment to keep the closure small
   rm(snow_raster_ind, snow_data_yml, timestep, timesteps_all_ind, 

--- a/build/status/Ml9wcm9jZXNzL291dC9zbm93X3Jhc3Rlcl9pbnRlcnBfZmlsZXMucmRzLmluZA.yml
+++ b/build/status/Ml9wcm9jZXNzL291dC9zbm93X3Jhc3Rlcl9pbnRlcnBfZmlsZXMucmRzLmluZA.yml
@@ -1,0 +1,14 @@
+version: 0.3.0
+name: 2_process/out/snow_raster_interp_files.rds.ind
+type: file
+hash: 78fb9d7e3ee791d79609544307eda757
+time: 2019-05-23 19:02:21 UTC
+depends:
+  2_process/out/timesteps.rds.ind: 6283084b2032683ccfeccd8c4106a3e5
+  timestep: 234a2a5581872457b9fe1187d1616b13
+  1_fetch/log/1_fetch_snow_tasks.ind: b329b01c15b8f2d98830613d84cd7d55
+fixed: e8431baccc6e1dc13df05e9591e671d7
+code:
+  functions:
+    interpolate_snow_raster_layers: 1bb999535d3ccb3f194ec44ad8f120fe
+


### PR DESCRIPTION
Fixes https://github.com/usgs-makerspace/makerspace-sandbox/issues/43

Run this with new dates (March to May 2019). This created snow raster files that were 11 GB so I had to adjust the code to write multiple raster files out after interpolation because `writeRaster` could not handle something that big. Currently, this splits it into two raster files. We might need to split into more than just two if we add more dates to this time period.

Does not include any style changes.