### PR TITLE
Use scipiper combiners to be smart about frames used in animation

### DIFF
--- a/6_visualize.yml
+++ b/6_visualize.yml
@@ -239,8 +239,9 @@ targets:
     command: combine_animation_frames(
       gif_file=target_name,
       animation_cfg=animation_cfg,
-      task_names=NULL,
-      intro_config = intro_config,
-      n_outro = I(3))
+      frame_ind_intro = "6_visualize/log/6_intro_gif_tasks.ind",
+      frame_ind_storm = "6_visualize/log/6_storm_gif_tasks.ind",
+      frame_ind_outro = "6_visualize/log/6_outro_gif_frames.ind",
+      intro_config = intro_config)
   6_visualize/out/animation_a.gif.ind:
     command: gd_put(target_name, '6_visualize/out/animation_a.gif')

--- a/6_visualize/src/combine_animation_frames.R
+++ b/6_visualize/src/combine_animation_frames.R
@@ -51,8 +51,6 @@ combine_animation_frames <- function(gif_file, animation_cfg, frame_ind_intro=NU
 
 extract_filenames_from_ind <- function(ind_file) {
   filename_hash_list <- readLines(ind_file)
-  only_names <- lapply(filename_hash_list, function(fn) {
-    head(unlist(strsplit(fn, split = ":")), 1)
-  })
-  return(unlist(only_names))
+  only_names <- unlist(lapply(strsplit(filename_hash_list, ":"), `[`, 1))
+  return(only_names)
 }

--- a/6_visualize/src/combine_animation_frames.R
+++ b/6_visualize/src/combine_animation_frames.R
@@ -1,25 +1,33 @@
-combine_animation_frames <- function(gif_file, animation_cfg, task_names=NULL, intro_config, n_outro) {
+combine_animation_frames <- function(gif_file, animation_cfg, frame_ind_intro=NULL, frame_ind_storm=NULL, frame_ind_outro=NULL, intro_config) {
 
   # run imageMagick convert to build a gif
-  if(is.null(task_names)) task_names <- '*'
-  png_files <- paste(sprintf('6_visualize/tmp/gif_frame_%s.png', task_names), collapse=' ')
+
+  # TO DO: situation where any of the frame inds are NULL
+
+  # Gather appropriate file names (not just whatever is in the directory)
+  png_files_intro <- extract_filenames_from_ind(frame_ind_intro)
+  png_files_storm <- extract_filenames_from_ind(frame_ind_storm)
+  png_files_outro <- extract_filenames_from_ind(frame_ind_outro)
+  png_files <- c(png_files_intro, png_files_storm, png_files_outro)
+  png_files_string <- paste(png_files, collapse=' ')
+
   tmp_dir <- './6_visualize/tmp/magick'
   if(!dir.exists(tmp_dir)) dir.create(tmp_dir)
   magick_command <- sprintf(
     'convert -define registry:temporary-path=%s -limit memory 24GiB -delay %d -loop 0 %s %s',
-    tmp_dir, animation_cfg$frame_delay_cs, png_files, gif_file)
+    tmp_dir, animation_cfg$frame_delay_cs, png_files_string, gif_file)
   if(Sys.info()[['sysname']] == "Windows") {
     magick_command <- sprintf('magick %s', magick_command)
   }
   system(magick_command)
 
   # simplify the gif with gifsicle - cuts size by about 2/3
-  stopifnot(task_names == '*')
 
-  png_dir <- dirname(png_files)
-  png_patt <- basename(png_files) %>% tools::file_path_sans_ext()
-  total_frames <- grepl(dir(png_dir), pattern = png_patt) %>% sum()
   # how many intro frames? how many storm frames? how many outro frames?
+  total_frames <- length(png_files)
+  n_intro <- length(png_files_intro)
+  n_outro <- length(png_files_outro)
+
   intro_delay <- intro_config$frame_delay_cs
   storm_delay <- animation_cfg$frame_delay_cs
   outro_delay <- 200
@@ -30,8 +38,8 @@ combine_animation_frames <- function(gif_file, animation_cfg, task_names=NULL, i
     paste(paste(sprintf('-d%s "#', delay), seq(start_frame-1, end_frame-1), sep = '') %>%
             paste('"', sep = ''), collapse = " ")
   }
-  intro_delays <- calc_delays(intro_delay, 1, intro_config$n_frames)
-  storm_delays <- calc_delays(storm_delay, intro_config$n_frames+1, total_frames-n_outro-1)
+  intro_delays <- calc_delays(intro_delay, 1, n_intro)
+  storm_delays <- calc_delays(storm_delay, n_intro+1, total_frames-n_outro-1)
   # freeze the last storm frame too for as long as we are showing each outro frame:
   last_storm_delay <- calc_delays(freeze_delay, total_frames-n_outro, total_frames-n_outro)
   outro_delays <- calc_delays(outro_delay, total_frames-n_outro+1, total_frames-1)
@@ -39,4 +47,12 @@ combine_animation_frames <- function(gif_file, animation_cfg, task_names=NULL, i
 
   gifsicle_command <- sprintf('gifsicle -b -O3 %s %s %s %s %s %s --colors 256', gif_file, intro_delays, storm_delays, last_storm_delay, outro_delays, final_delay)
   system(gifsicle_command)
+}
+
+extract_filenames_from_ind <- function(ind_file) {
+  filename_hash_list <- readLines(ind_file)
+  only_names <- lapply(filename_hash_list, function(fn) {
+    head(unlist(strsplit(fn, split = ":")), 1)
+  })
+  return(unlist(only_names))
 }

--- a/6_visualize/src/create_gif_makefile.R
+++ b/6_visualize/src/create_gif_makefile.R
@@ -7,8 +7,7 @@ create_intro_gif_makefile <- function(makefile, task_plan, remake_file) {
       '6_visualize/src/prep_spark_line_fun.R',
       '6_visualize/src/prep_gage2spark_fun.R',
       '6_visualize/src/create_animation_frame.R'),
-    file_extensions=c('feather','ind'),
-    ind_complete=TRUE)
+    file_extensions=c('feather','ind'))
 }
 
 create_storm_gif_makefile <- function(makefile, task_plan, remake_file) {
@@ -23,6 +22,5 @@ create_storm_gif_makefile <- function(makefile, task_plan, remake_file) {
       '6_visualize/src/prep_storm_point_fun.R',
       '6_visualize/src/prep_precip_fun.R',
       '6_visualize/src/prep_spark_line_fun.R'),
-    file_extensions=c('feather','ind'),
-    ind_complete=TRUE)
+    file_extensions=c('feather','ind'))
 }


### PR DESCRIPTION
The new scipiper task combiner code can help us to be prescriptive about the frames used in the final animation rather than just using whatever is in the directory. I tested this out on the `Makerspace-example` branch by adding another image file with the same naming scheme/size/etc and it was not used in the final animation 🎉 

To use this, you will need to use the [scipiper task_combiner branch](https://github.com/USGS-R/scipiper/tree/task_combiners) which is not yet merged into `scipiper` (maybe we should wait to merge this?).