### PR TITLE
Sally 2020 - remove RDGs, nudge text, and remove watermark

### DIFF
--- a/6_visualize/in/6_outro_gif_tasks_template.mustache
+++ b/6_visualize/in/6_outro_gif_tasks_template.mustache
@@ -29,7 +29,6 @@ targets:
       ltn_fun_1,
       gage_sites_fun_a_{{last_task}},
       legend_fun_a_{{last_task}},
-      timeline_fun_a_{{last_task}},
       cities_fun,
       watermark_fun)
 
@@ -51,7 +50,6 @@ targets:
       readmore_fun_1,
       gage_sites_fun_a_{{last_task}},
       legend_fun_a_{{last_task}},
-      timeline_fun_a_{{last_task}},
       cities_fun,
       watermark_fun)
 

--- a/6_visualize/in/6_outro_gif_tasks_template.mustache
+++ b/6_visualize/in/6_outro_gif_tasks_template.mustache
@@ -10,28 +10,6 @@ packages:
   - showtext
 
 targets:
-  rdgs_fun_1:
-    command: prep_outro_rdgs_fun(
-      rdg_ind="2_process/out/rapid_dep_sites_proj.rds.ind",
-      gage_color_config, outro_placement, legend_text_cfg, opacity=1)
-
-  6_visualize/tmp/gif_frame_a_z001_outro_rdgs_1.png:
-    command: create_animation_frame(
-      png_file=target_name,
-      config=storm_frame_config,
-      view_fun,
-      basemap_fun,
-      ocean_name_fun,
-      precip_raster_fun_a_{{last_task}},
-      storm_line_fun_a_{{last_task}},
-      storm_point_fun_a_{{last_task}},
-      rivers_fun,
-      gage_sites_fun_a_{{last_task}},
-      rdgs_fun_1,
-      legend_fun_a_{{last_task}},
-      timeline_fun_a_{{last_task}},
-      cities_fun,
-      watermark_fun)
 
   ltn_fun_1:
     command: prep_outro_allsites_fun(
@@ -50,7 +28,6 @@ targets:
       rivers_fun,
       ltn_fun_1,
       gage_sites_fun_a_{{last_task}},
-      rdgs_fun_1,
       legend_fun_a_{{last_task}},
       timeline_fun_a_{{last_task}},
       cities_fun,
@@ -73,7 +50,6 @@ targets:
       ltn_fun_1,
       readmore_fun_1,
       gage_sites_fun_a_{{last_task}},
-      rdgs_fun_1,
       legend_fun_a_{{last_task}},
       timeline_fun_a_{{last_task}},
       cities_fun,
@@ -81,7 +57,6 @@ targets:
 
   6_outro_gif_tasks:
     depends:
-      - 6_visualize/tmp/gif_frame_a_z001_outro_rdgs_1.png
       - 6_visualize/tmp/gif_frame_a_z002_outro_ltn_1.png
       - 6_visualize/tmp/gif_frame_a_z003_outro_readmore_1.png
     command: sc_indicate(I('6_visualize/log/6_outro_gif_tasks.ind'), hash_depends=I(TRUE), depends_target=I('6_outro_gif_tasks'), depends_makefile=I('6_outro_gif_tasks.yml'))

--- a/6_visualize/in/6_outro_gif_tasks_template.mustache
+++ b/6_visualize/in/6_outro_gif_tasks_template.mustache
@@ -29,8 +29,7 @@ targets:
       ltn_fun_1,
       gage_sites_fun_a_{{last_task}},
       legend_fun_a_{{last_task}},
-      cities_fun,
-      watermark_fun)
+      cities_fun)
 
 
   readmore_fun_1:
@@ -50,8 +49,7 @@ targets:
       readmore_fun_1,
       gage_sites_fun_a_{{last_task}},
       legend_fun_a_{{last_task}},
-      cities_fun,
-      watermark_fun)
+      cities_fun)
 
   6_outro_gif_tasks:
     depends:

--- a/6_visualize/out/animation_a.gif.ind
+++ b/6_visualize/out/animation_a.gif.ind
@@ -1,0 +1,2 @@
+hash: 8c21fdb1326e21fe229a399b8feca170
+

--- a/6_visualize/src/create_gif_tasks.R
+++ b/6_visualize/src/create_gif_tasks.R
@@ -81,8 +81,8 @@ create_intro_gif_tasks <- function(intro_config, folders, storm_track_cfg, storm
         "gage_sites_initial,",
         "gage2spark_fun_%s,"=cur_task$tn,
         "legend_fun_%s,"=cur_task$tn,
-        "cities_fun,",
-        "watermark_fun)"
+        "cities_fun)"
+        #"watermark_fun)"
       )
     }
   )
@@ -255,8 +255,8 @@ create_storm_gif_tasks <- function(timestep, storm_track_cfg, folders){
         "gage_sites_fun_%s,"=cur_task$tn,
         "legend_fun_%s,"=cur_task$tn,
         "timeline_fun_%s,"=cur_task$tn,
-        "cities_fun,",
-        "watermark_fun)",
+        "cities_fun)",
+        #"watermark_fun",
         #"streamdata_%s,"= cur_task$tn,
         sep="\n      ")
     }
@@ -279,8 +279,8 @@ create_storm_gif_tasks <- function(timestep, storm_track_cfg, folders){
         if(has_storm_track) c("storm_point_fun_%s,"=cur_task$tn),
         "legend_fun_%s,"=cur_task$tn,
         "bbox_fun,",
-        "cities_fun,",
-        "watermark_fun)",
+        "cities_fun)",
+        #"watermark_fun)",
         sep="\n      ")
     }
   )

--- a/6_visualize/src/prep_outro_funs.R
+++ b/6_visualize/src/prep_outro_funs.R
@@ -101,7 +101,7 @@ prep_outro_readmore_fun <- function(outro_placement, legend_text_cfg, opacity=1)
     # plot text and legend
     text(x=x_title, y=y_title, labels="STAY SAFE DURING FLOODS", adj=c(0, 1),
          cex=2.2, col=legend_text_cfg$col, family = 'Oswald')
-    text_chars <- "Learn more about USGS response to Florence at www.usgs.gov/florence"
+    text_chars <- "Learn more about USGS response to Sally at www.usgs.gov/sally"
     text(x=x_text, y=y_text, labels=text_chars, adj=c(0, 1),
          cex=1.5, col=legend_text_cfg$col, family = 'abel')
   }

--- a/6_visualize/src/prep_outro_funs.R
+++ b/6_visualize/src/prep_outro_funs.R
@@ -65,12 +65,12 @@ prep_outro_allsites_fun <- function(allsites_ind="2_process/out/gage_sites_geom.
 
     # plan text and legend coordinates
     user_coords <- par()$usr
-    x_title <- user_coords[1] + 0.535 * diff(user_coords[1:2])
-    x_text <- user_coords[1] + 0.535 * diff(user_coords[1:2])
-    y_title <- user_coords[3] + 0.49 * diff(user_coords[3:4])
-    y_text <- user_coords[3] + 0.43 * diff(user_coords[3:4])
-    x_dot <- x_text + 0.1635 * diff(user_coords[1:2])
-    y_dot <- y_text - 0.061 * diff(user_coords[3:4])
+    x_title <- user_coords[1] + 0.495 * diff(user_coords[1:2])
+    x_text <- user_coords[1] + 0.495 * diff(user_coords[1:2])
+    y_title <- user_coords[3] + 0.80 * diff(user_coords[3:4])
+    y_text <- user_coords[3] + 0.74 * diff(user_coords[3:4])
+    x_dot <- x_text + 0.1930 * diff(user_coords[1:2])
+    y_dot <- y_text - 0.055 * diff(user_coords[3:4])
     # plot text and legend
     text(x=x_title, y=y_title, labels="NATIONAL SCALE OBSERVING NETWORK", adj=c(0, 1),
          cex=2.2, col=legend_text_cfg$col, family = 'Oswald')
@@ -80,7 +80,7 @@ the southeastern US are shown on the map."
     text(x=x_text, y=y_text, labels=text_chars, adj=c(0, 1),
          cex=1.8, col=legend_text_cfg$col, family = 'abel')
 
-    points(x=x_dot, y=y_dot, pch = ltn_pch, col = ltn_col, cex = ltn_cex)
+    points(x=x_dot, y=y_dot, pch = ltn_pch, col = ltn_col, cex = ltn_cex*2.0)
   }
   return(plot_fun)
 }
@@ -93,10 +93,10 @@ prep_outro_readmore_fun <- function(outro_placement, legend_text_cfg, opacity=1)
 
     # plan text coordinates
     user_coords <- par()$usr
-    x_title <- user_coords[1] + 0.52 * diff(user_coords[1:2])
-    x_text <- user_coords[1] + 0.43 * diff(user_coords[1:2])
-    y_title <- user_coords[3] + 0.17 * diff(user_coords[3:4])
-    y_text <- user_coords[3] + 0.11 * diff(user_coords[3:4])
+    x_title <- user_coords[1] + 0.59 * diff(user_coords[1:2])
+    x_text <- user_coords[1] + 0.49 * diff(user_coords[1:2])
+    y_title <- user_coords[3] + 0.35 * diff(user_coords[3:4])
+    y_text <- user_coords[3] + 0.29 * diff(user_coords[3:4])
 
     # plot text and legend
     text(x=x_title, y=y_title, labels="STAY SAFE DURING FLOODS", adj=c(0, 1),

--- a/build/status/Nl92aXN1YWxpemUvb3V0L2FuaW1hdGlvbl9hLmdpZi5pbmQ.yml
+++ b/build/status/Nl92aXN1YWxpemUvb3V0L2FuaW1hdGlvbl9hLmdpZi5pbmQ.yml
@@ -1,0 +1,11 @@
+version: 0.3.0
+name: 6_visualize/out/animation_a.gif.ind
+type: file
+hash: b6be83b649de4df6f8c08afb6c89ea27
+time: 2020-09-23 18:29:59 UTC
+depends:
+  6_visualize/out/animation_a.gif: 8c21fdb1326e21fe229a399b8feca170
+fixed: b125b0bf925d0c6b35a036a2042d89b2
+code:
+  functions: {}
+

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -45,7 +45,7 @@ timeline_style:
   line_lwd: 0.7
   line_lty: 3
   line_col: "gray45"
-  font_cex: 1.5
+  font_cex: 1.3
   font_col: "gray30"
 
 storm_line:

--- a/viz_config.yml
+++ b/viz_config.yml
@@ -82,12 +82,13 @@ component_placement:
     ytop: 0.93 # top of the first sparkline. spark title goes above. don't use 1.0 - it causes an error (invalid value specified for graphics parameter "fig")
     ytimeline: 0.24 # y location of timeline; this will use xright and xleft from sparks
     ytimeline_text: 0.205 # y location of timeline dates (0.035 below line has worked well)
+  # These positions are not actually being used right now ...
   outro:
     # outro text & legend roughly, but not exactly, fit where the sparklines were
     xleft: 0.55
     xright: 0.99
-    ytop_ltn: 0.6 # top y coordinate of the text and legend for the long-term network
-    ytop_stn: 0.85 # top y coordinate of the text and legend for the short-term network
+    ytop_ltn: 0.85 # top y coordinate of the text and legend for the long-term network
+    #ytop_stn: 0.85 # top y coordinate of the text and legend for the short-term network
     ytop_more: 0.4 # top y coordinate of the text and URL for where to learn more
 
 


### PR DESCRIPTION
[Animation produced by this PR](https://drive.google.com/drive/u/3/folders/1ebHKy2lLhqp91GugeloVL6q1lTbiMMi3). Removed RDGs because there were only two. Nudged outro text around to look good without the RDGs. Removed the watermark because we built the frames using Windows so that the rivers were not as funky (on Mac, their resolution was almost too high so it was drawing them strangely) but we lose crispness on other components. Going to add the watermark back in at a higher res in Photoshop. 

Also, frames were shared [here](https://drive.google.com/drive/u/3/folders/1ZoKAYTOHoiwTONe7mk8qyyMcukE3pG5s) so that @collnell can take them and make the final final animation (add watermark, stitch together so that outro frames can be read by a human, and compress final gif so that it is <= twitter mobile limit of 5 MB).