### PR TITLE
fixes from `Henri-2021` needed for build

### DIFF
--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -14,6 +14,8 @@ packages:
   - dplyr
   - xml2
   - jsonlite
+  - rmapshaper
+  - nhdplusTools
 
 file_extensions:
   - ind

--- a/1_fetch/src/fetch_precip_nc.R
+++ b/1_fetch/src/fetch_precip_nc.R
@@ -13,17 +13,17 @@ fetch_precip_data <- function(ind_file, view_polygon, times) {
   # create the stencil from the bbox of the view_polygon
   crs <- st_crs(view_polygon)
   bbox <- st_bbox(view_polygon)
-  
+
   precip_boundary <- "POLYGON ((-80.74672 19.80368, -119.023 23.117, -134.043 53.51192, -124.9736 55.90588, -114.5051 57.4236, -102.7265 57.82357, -91.28471 56.95466, -81.85043 55.19577, -73.63054 52.69872, -66.4331 49.53428, -59.95137 45.6187, -80.74672 19.80368))" %>%
     st_as_sfc(crs = st_crs("+proj=longlat +datum=WGS84"))
-  
+
   stencil <- st_transform(view_polygon, "+proj=longlat +datum=WGS84") %>%
     st_intersection(precip_boundary)
-  
+
   stencil <- as_Spatial(stencil)
-  stencil@proj4string <- sp::CRS("+proj=longlat +datum=WGS84") # geoknife complains otherwise
+  sp::proj4string(stencil)  <- sp::CRS("+proj=longlat +datum=WGS84") # geoknife complains otherwise
   stencil <- geoknife::simplegeom(stencil)
-  
+
   # run the job and retrieve the results
   job <- geoknife(stencil = stencil, fabric = fabric, knife = knife)
   nc_file <- as_data_file(ind_file)
@@ -42,11 +42,11 @@ fetch_precip_data <- function(ind_file, view_polygon, times) {
 # x <- matrix(rep(c(1:ncol(lon)), nrow(lon)),
 #             nrow = nrow(lon), ncol = ncol(lon),
 #             byrow = TRUE)
-# 
+#
 # y <- matrix(rep(c(1:nrow(lon)), ncol(lon)),
 #             nrow = nrow(lon), ncol = ncol(lon),
 #             byrow = FALSE)
-# 
+#
 # sf_points <- data.frame(x = matrix(x, ncol = 1),
 #                         y = matrix(y, ncol = 1),
 #                         lon = matrix(lon, ncol = 1),

--- a/1_fetch/src/fetch_river_geometry.R
+++ b/1_fetch/src/fetch_river_geometry.R
@@ -3,11 +3,8 @@ fetch_major_river_geoms <- function(ind_file, view_polygon, fetch_streamorder) {
   bbox_sf <- st_as_sfc(st_bbox(view_polygon))
 
   sf_major_rivers <- get_nhdplus(AOI = bbox_sf,
-                                 realization = "flowline",
-                                 streamorder = fetch_streamorder$fetch_streamorder) %>%
-    group_by(gnis_id, streamorde) %>%
-    summarize() %>%
-    ms_simplify()
+                           realization = "flowline",
+                           streamorder = fetch_streamorder$fetch_streamorder)
 
   data_file <- as_data_file(ind_file)
   saveRDS(sf_major_rivers, data_file)
@@ -19,7 +16,7 @@ fetch_waterbody_geoms <- function(ind_file, view_polygon, fetch_waterbody_areasq
   bbox_sf <- st_as_sfc(st_bbox(view_polygon))
 
   sf_waterbodies <- get_waterbodies(AOI = bbox_sf,
-                                    buffer = 0) %>%
+                                 buffer = 0) %>%
     filter(areasqkm > fetch_waterbody_areasqkm$fetch_waterbody_areasqkm) %>%
     ms_simplify()
 
@@ -30,7 +27,7 @@ fetch_waterbody_geoms <- function(ind_file, view_polygon, fetch_waterbody_areasq
 
 fetch_gage_river_geoms <- function(ind_file, view_polygon, sites_ind) {
 
-  sites <- readRDS(sc_retrieve(sites_ind))
+  sites <- readRDS(sc_retrieve(sites_ind, remake_file = getOption("scipiper.remake_file")))
 
   if(nrow(sites) > 30) {
     set.seed(42)
@@ -57,9 +54,12 @@ fetch_gage_river_geoms <- function(ind_file, view_polygon, sites_ind) {
 }
 
 name_adder <- function(x, updn) {
+  browser()
   lapply(seq_along(x), function(y, n, r, updn) {
+    print(y)
     mutate(y[[r]], site_id = n[[r]]) %>%
-    mutate(up_down = updn)},
+    mutate(up_down = updn)
+    },
     n = names(x), y = x, updn = updn)
 }
 
@@ -76,6 +76,5 @@ navigate_nldi <- function(f_id, f_source, mode = "UM",
   if(!is.null(distance)) {
     url <- paste0(url, "?distance=", distance)
   }
-
   return(rawToChar(httr::GET(url)$content))
 }

--- a/1_fetch/src/fetch_river_geometry.R
+++ b/1_fetch/src/fetch_river_geometry.R
@@ -1,34 +1,13 @@
 fetch_major_river_geoms <- function(ind_file, view_polygon, fetch_streamorder) {
 
-  bbox <- st_bbox(st_transform(view_polygon, 4326))
+  bbox_sf <- st_as_sfc(st_bbox(view_polygon))
 
-  postURL <- "https://cida.usgs.gov/nwc/geoserver/nhdplus/ows"
-
-  filterXML <- paste0('<?xml version="1.0"?>',
-                      '<wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" service="WFS" version="1.1.0" outputFormat="application/json" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">',
-                      '<wfs:Query xmlns:feature="http://gov.usgs.cida/nhdplus" typeName="feature:nhdflowline_network" srsName="EPSG:4326">',
-                      '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">',
-                      '<ogc:And>',
-                      '<ogc:PropertyIsGreaterThan>',
-                      '<ogc:PropertyName>streamorde</ogc:PropertyName>',
-                      '<ogc:Literal>',fetch_streamorder,'</ogc:Literal>',
-                      '</ogc:PropertyIsGreaterThan>',
-                      '<ogc:BBOX>',
-                      '<ogc:PropertyName>the_geom</ogc:PropertyName>',
-                      '<gml:Envelope>',
-                      '<gml:lowerCorner>',bbox[2]," ",bbox[1],'</gml:lowerCorner>',
-                      '<gml:upperCorner>',bbox[4]," ",bbox[3],'</gml:upperCorner>',
-                      '</gml:Envelope>',
-                      '</ogc:BBOX>',
-                      '</ogc:And>',
-                      '</ogc:Filter>',
-                      '</wfs:Query>',
-                      '</wfs:GetFeature>')
-
-  out <- httr::POST(postURL, body = filterXML)
-
-  sf_major_rivers <- read_sf(rawToChar(out$content)) %>%
-    st_transform(st_crs(view_polygon))
+  sf_major_rivers <- get_nhdplus(AOI = bbox_sf,
+                                 realization = "flowline",
+                                 streamorder = fetch_streamorder$fetch_streamorder) %>%
+    group_by(gnis_id, streamorde) %>%
+    summarize() %>%
+    ms_simplify()
 
   data_file <- as_data_file(ind_file)
   saveRDS(sf_major_rivers, data_file)
@@ -37,35 +16,12 @@ fetch_major_river_geoms <- function(ind_file, view_polygon, fetch_streamorder) {
 
 fetch_waterbody_geoms <- function(ind_file, view_polygon, fetch_waterbody_areasqkm) {
 
-  bbox <- st_bbox(st_transform(view_polygon, 4326))
+  bbox_sf <- st_as_sfc(st_bbox(view_polygon))
 
-  postURL <- "https://cida.usgs.gov/nwc/geoserver/nhdplus/ows"
-
-  filterXML <- paste0('<?xml version="1.0"?>',
-                      '<wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" service="WFS" version="1.1.0" outputFormat="application/json" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">',
-                      '<wfs:Query xmlns:feature="http://gov.usgs.cida/nhdplus" typeName="feature:nhdwaterbody" srsName="EPSG:4326">',
-                      '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">',
-                      '<ogc:And>',
-                      '<ogc:PropertyIsGreaterThan>',
-                      '<ogc:PropertyName>areasqkm</ogc:PropertyName>',
-                      '<ogc:Literal>',fetch_waterbody_areasqkm,'</ogc:Literal>',
-                      '</ogc:PropertyIsGreaterThan>',
-                      '<ogc:BBOX>',
-                      '<ogc:PropertyName>the_geom</ogc:PropertyName>',
-                      '<gml:Envelope>',
-                      '<gml:lowerCorner>',bbox[2]," ",bbox[1],'</gml:lowerCorner>',
-                      '<gml:upperCorner>',bbox[4]," ",bbox[3],'</gml:upperCorner>',
-                      '</gml:Envelope>',
-                      '</ogc:BBOX>',
-                      '</ogc:And>',
-                      '</ogc:Filter>',
-                      '</wfs:Query>',
-                      '</wfs:GetFeature>')
-
-  out <- httr::POST(postURL, body = filterXML)
-
-  sf_waterbodies <- read_sf(rawToChar(out$content)) %>%
-    st_transform(st_crs(view_polygon))
+  sf_waterbodies <- get_waterbodies(AOI = bbox_sf,
+                                    buffer = 0) %>%
+    filter(areasqkm > fetch_waterbody_areasqkm$fetch_waterbody_areasqkm) %>%
+    ms_simplify()
 
   data_file <- as_data_file(ind_file)
   saveRDS(sf_waterbodies, data_file)

--- a/1_fetch/src/fetch_river_geometry.R
+++ b/1_fetch/src/fetch_river_geometry.R
@@ -54,9 +54,8 @@ fetch_gage_river_geoms <- function(ind_file, view_polygon, sites_ind) {
 }
 
 name_adder <- function(x, updn) {
-  browser()
+
   lapply(seq_along(x), function(y, n, r, updn) {
-    print(y)
     mutate(y[[r]], site_id = n[[r]]) %>%
     mutate(up_down = updn)
     },

--- a/1_fetch/src/fetch_sites.R
+++ b/1_fetch/src/fetch_sites.R
@@ -5,7 +5,7 @@
 fetch_states_from_sf <- function(sf_ind) {
 
   # read the sf object from the shared cache
-  sf_object <- readRDS(sc_retrieve(sf_ind))
+  sf_object <- readRDS(sc_retrieve(sf_ind, remake_file = getOption("scipiper.remake_file")))
 
   state_names <- sf_object$ID[!grepl(",", sf_object$ID)]
 
@@ -71,7 +71,7 @@ fetch_rapid_dep_sites <- function(ind_file, event) {
     rdgs <- data.frame()
   } else {
     # fetch the rapid deployment gages (RDGs) from the STN web services
-    url <- sprintf('https://stn.wim.usgs.gov/STNServices/Instruments/FilteredInstruments.json?Event=%d&EventType=&EventStatus=&States=&County=&CurrentStatus=&CollectionCondition=&SensorType=5&DeploymentType=', event)
+    url <- sprintf('https://stn.wim.usgs.gov/STNServices/Instruments/FilteredInstruments.json?Event=%d&EventType=&EventStatus=&States=&County=&CurrentStatus=&CollectionCondition=&SensorType=1&DeploymentType=1,2', event)
 
     rdgs <- jsonlite::fromJSON(url)
     if(length(rdgs) > 0) {

--- a/1_fetch/src/fetch_sites.R
+++ b/1_fetch/src/fetch_sites.R
@@ -71,7 +71,7 @@ fetch_rapid_dep_sites <- function(ind_file, event) {
     rdgs <- data.frame()
   } else {
     # fetch the rapid deployment gages (RDGs) from the STN web services
-    url <- sprintf('https://stn.wim.usgs.gov/STNServices/Instruments/FilteredInstruments.json?Event=%d&EventType=&EventStatus=&States=&County=&CurrentStatus=&CollectionCondition=&SensorType=1&DeploymentType=1,2', event)
+    url <- sprintf('https://stn.wim.usgs.gov/STNServices/Instruments/FilteredInstruments.json?Event=%d&EventType=&EventStatus=&States=&County=&CurrentStatus=&CollectionCondition=&SensorType=5&DeploymentType=', event)
 
     rdgs <- jsonlite::fromJSON(url)
     if(length(rdgs) > 0) {

--- a/1_fetch/src/fetch_streamdata.R
+++ b/1_fetch/src/fetch_streamdata.R
@@ -1,6 +1,6 @@
 fetch_streamdata <- function(ind_file, sites_ind, dates, stream_params, gd_config) {
 
-  sites <- readRDS(scipiper::sc_retrieve(sites_ind))
+  sites <- readRDS(scipiper::sc_retrieve(sites_ind, remake_file = getOption("scipiper.remake_file")))
 
   message('  starting download of NWIS data at ', Sys.time())
   # pad the date range by 1 day in each direction because our dates parameter

--- a/1_fetch/src/map_utils.R
+++ b/1_fetch/src/map_utils.R
@@ -27,7 +27,7 @@ bbox_to_polygon <- function(bbox, bbox_crs = "+init=epsg:4326", return_crs = NUL
 #' @details if `projection` is missing, it is assumed to be "+init=epsg:4326"
 #' @return an sf polygon that contains the `bbox` specfied at the aspect ratio specified
 as_view_polygon <- function(view_config) {
-  
+
   # the projected polygon specified by the user
   bbox_projected <- bbox_to_polygon(bbox = unlist(view_config$bbox), return_crs = view_config$projection)
   poly_bbox <- as.numeric(sf::st_bbox(bbox_projected))
@@ -41,7 +41,7 @@ as_view_polygon <- function(view_config) {
 
   } else { # taller than it should be
     # new x dimension
-    new_x_diff <- diff(poly_bbox[c(2,4)]) * aspect 
+    new_x_diff <- diff(poly_bbox[c(2,4)]) * aspect
     # new x dimension - existing y dimension
     x_buffer <- new_x_diff - diff(poly_bbox[c(1,3)])
     # subtract half the buffer from min x, add half to max x
@@ -65,7 +65,8 @@ post_view_polygon <- function(ind_file, view_config) {
 
 #' download and read in the view polygon
 get_view_polygon <- function(view_poly_ind) {
-  readRDS(sc_retrieve(view_poly_ind))
+  readRDS(sc_retrieve(view_poly_ind,
+                      remake_file = getOption("scipiper.remake_file")))
 }
 
 

--- a/2_process/src/clean_streamdata.R
+++ b/2_process/src/clean_streamdata.R
@@ -1,7 +1,7 @@
 # this function contains hard-coded, ~manual removal of specific points that we don't believe
 clean_streamdata <- function(ind_file, normalized_ind_file = '2_process/out/normalized_streamdata.rds.ind') {
 
-  normalized <- readRDS(sc_retrieve(normalized_ind_file))
+  normalized <- readRDS(sc_retrieve(normalized_ind_file, remake_file = getOption("scipiper.remake_file")))
   cleaned <- normalized
   # cleaned <- mutate(
   #   normalized,

--- a/2_process/src/extract_storm_line.R
+++ b/2_process/src/extract_storm_line.R
@@ -8,7 +8,7 @@
 extract_storm_line <- function(ind_file, storm_shp_ind, cfg){
 
   # get the shp zip file from Drive if we don't already have it
-  storm_shp_file <- sc_retrieve(storm_shp_ind)
+  storm_shp_file <- sc_retrieve(storm_shp_ind, remake_file = getOption("scipiper.remake_file"))
 
   if(file.size(storm_shp_file) == 0) {
     track_proj <- NULL

--- a/2_process/src/extract_storm_points.R
+++ b/2_process/src/extract_storm_points.R
@@ -8,7 +8,7 @@
 extract_storm_points <- function(ind_file, storm_shp_ind, cfg){
 
   # get the shp zip file from Drive if we don't already have it
-  storm_shp_file <- sc_retrieve(storm_shp_ind)
+  storm_shp_file <- sc_retrieve(storm_shp_ind, remake_file = getOption("scipiper.remake_file"))
 
   if(file.size(storm_shp_file) == 0) {
     points_proj <- NULL

--- a/2_process/src/filter_sites_custom-example.R
+++ b/2_process/src/filter_sites_custom-example.R
@@ -5,7 +5,7 @@
 filter_sites_custom <- function(ind_file, sites_ind) {
 
   # get sites data frame with NWS data
-  sites_df <- readRDS(sc_retrieve(sites_ind))
+  sites_df <- readRDS(sc_retrieve(sites_ind), remake_file = getOption("scipiper.remake_file"))
 
   ### filter sites_df here ###
   sites_info_subset <- sites_df

--- a/2_process/src/filter_sites_geom.R
+++ b/2_process/src/filter_sites_geom.R
@@ -8,8 +8,8 @@
 #' @param proj_str string of projection to transform to
 filter_sites_geom <- function(ind_file, sites_ind, view_polygon, focus_geoms_ind, proj_str) {
 
-  focus_geoms <- readRDS(sc_retrieve(focus_geoms_ind))
-  sites_df <- readRDS(sc_retrieve(sites_ind))
+  focus_geoms <- readRDS(sc_retrieve(focus_geoms_ind, remake_file = getOption("scipiper.remake_file")))
+  sites_df <- readRDS(sc_retrieve(sites_ind, remake_file = getOption("scipiper.remake_file")))
 
   # get sites as sf object
   sites_df <- sites_df %>%

--- a/2_process/src/filter_using_custom.R
+++ b/2_process/src/filter_using_custom.R
@@ -6,8 +6,8 @@
 #' @param sites_custom_ind indicator file for data.frame with at least site_no
 filter_using_custom <- function(ind_file, sites_ind, sites_custom_ind) {
 
-  sites_df <- readRDS(sc_retrieve(sites_ind))
-  sites_custom_df <- readRDS(sc_retrieve(sites_custom_ind))
+  sites_df <- readRDS(sc_retrieve(sites_ind, remake_file = getOption("scipiper.remake_file")))
+  sites_custom_df <- readRDS(sc_retrieve(sites_custom_ind, remake_file = getOption("scipiper.remake_file")))
   sites_final_df <- dplyr::filter(sites_df, site_no %in% sites_custom_df$site_no)
 
   # write the data file and the indicator file

--- a/2_process/src/interpolate_storm_points.R
+++ b/2_process/src/interpolate_storm_points.R
@@ -3,13 +3,13 @@
 interpolate_storm_points <- function(ind_file, timesteps_ind, coarse_points_ind) {
 
   # read in the coarse points storm track
-  coarse_points <- readRDS(sc_retrieve(coarse_points_ind))
+  coarse_points <- readRDS(sc_retrieve(coarse_points_ind, remake_file = getOption("scipiper.remake_file")))
 
   if(is.null(coarse_points)) {
     coords_interp_sf <- NULL
   } else {
     # get the vector of timepoints we want to include
-    timesteps <- readRDS(sc_retrieve(timesteps_ind))
+    timesteps <- readRDS(sc_retrieve(timesteps_ind, remake_file = getOption("scipiper.remake_file")))
 
     # interpolate the already-projected points to the timestamps we actually want
     coords_interp <- data_frame(

--- a/2_process/src/normalize_streamdata.R
+++ b/2_process/src/normalize_streamdata.R
@@ -2,9 +2,9 @@
 
 normalize_streamdata <- function(ind_file, raw_ind_file, sites_ind_file, timesteps_ind_file, stage_gap_threshold=3){
 
-  streamdata <- readRDS(sc_retrieve(raw_ind_file)) # NWIS raw data
-  gage_sites <- readRDS(sc_retrieve(sites_ind_file))
-  timesteps <- readRDS(sc_retrieve(timesteps_ind_file))
+  streamdata <- readRDS(sc_retrieve(raw_ind_file, remake_file = getOption("scipiper.remake_file"))) # NWIS raw data
+  gage_sites <- readRDS(sc_retrieve(sites_ind_file, remake_file = getOption("scipiper.remake_file")))
+  timesteps <- readRDS(sc_retrieve(timesteps_ind_file, remake_file = getOption("scipiper.remake_file")))
 
   # remove duplicated columns
   if(any(duplicated(names(streamdata)))) {

--- a/2_process/src/process_precip.R
+++ b/2_process/src/process_precip.R
@@ -193,6 +193,11 @@ process_precip_rasters <- function(ind_file, precip_spatial_ind,
 
   parallel::stopCluster(cl)
 
+  # Name the rasters the same as the timestep they represent
+  #   8.23.2021: this part used to just happen and downstream
+  #   steps depend on the naming to be like this.
+  names(rasters) <- as.character(time$time)
+
   data_file <- as_data_file(ind_file)
   saveRDS(rasters, data_file)
   gd_put(remote_ind=ind_file, local_source=data_file, mock_get='none')

--- a/2_process/src/process_precip.R
+++ b/2_process/src/process_precip.R
@@ -185,7 +185,7 @@ process_precip_rasters <- function(ind_file, precip_spatial_ind,
 
   cl <- parallel::makeCluster(rep("localhost", 4), type = "SOCK")
 
-  rasters <- snow::parSapply(cl, setNames(as.list(time$time_id), time$date_time),
+  rasters <- snow::parSapply(cl, setNames(as.list(time$time_id), time$time),
                              rasterize_precip,
                              precip_spatial = precip_spatial,
                              precip = precip,

--- a/2_process/src/process_precip.R
+++ b/2_process/src/process_precip.R
@@ -53,6 +53,9 @@ process_precip_values <- function(ind_file, precip_data_nc_ind,
   precip_spatial <- readRDS(sc_retrieve(precip_spatial_ind))
 
   t_vals <- get_time_nc(nc$dim$time)
+  # Strip out the `dim` attribute to avoid binding issues later,
+  #   see https://github.com/r-lib/vctrs/issues/1329
+  dim(t_vals) <- NULL
 
   start_date <- as.POSIXct(dates$start, tz = 'UTC')
   end_date <- as.POSIXct(dates$end, tz = 'UTC')

--- a/2_process/src/process_river_geoms.R
+++ b/2_process/src/process_river_geoms.R
@@ -1,6 +1,5 @@
 process_river_geoms <- function(ind_file,
                                 major_river_geoms_ind,
-                                gage_river_geoms_ind,
                                 waterbody_geoms_ind,
                                 river_geom_config) {
 
@@ -8,9 +7,9 @@ process_river_geoms <- function(ind_file,
   inland_threshold_sqkm <- river_geom_config$inland_threshold_sqkm
   simplification_tolerance_m <- river_geom_config$simplification_tolerance_m
 
-  sf_major_rivers <- readRDS(sc_retrieve(major_river_geoms_ind))
-  sf_gage_rivers <- readRDS(sc_retrieve(gage_river_geoms_ind))
-  sf_waterbodies <- readRDS(sc_retrieve(waterbody_geoms_ind))
+  sf_major_rivers <- readRDS(sc_retrieve(major_river_geoms_ind, remake_file = getOption("scipiper.remake_file")))
+  #sf_gage_rivers <- readRDS(sc_retrieve(gage_river_geoms_ind, remake_file = getOption("scipiper.remake_file")))
+  sf_waterbodies <- readRDS(sc_retrieve(waterbody_geoms_ind, remake_file = getOption("scipiper.remake_file")))
 
   outlets <- filter(sf_major_rivers,
                     (terminalfl == 1 &
@@ -30,20 +29,20 @@ process_river_geoms <- function(ind_file,
     st_cast("LINESTRING") %>%
     st_simplify(dTolerance = simplification_tolerance_m)
 
-  sf_gage_rivers <- sf_gage_rivers %>%
-    group_by(site_id, up_down) %>%
-    summarise() %>%
-    st_cast("MULTILINESTRING") %>%
-    ungroup() %>%
-    st_line_merge() %>%
-    st_cast("LINESTRING") %>%
-    st_simplify(dTolerance = simplification_tolerance_m)
+ # sf_gage_rivers <- sf_gage_rivers %>%
+ #   group_by(site_id, up_down) %>%
+ #   summarise() %>%
+ #   st_cast("MULTILINESTRING") %>%
+ #   ungroup() %>%
+ #   st_line_merge() %>%
+ #   st_cast("LINESTRING") %>%
+ #   st_simplify(dTolerance = simplification_tolerance_m)
 
   sf_waterbodies <- st_simplify(sf_waterbodies,
                                 dTolerance = simplification_tolerance_m)
 
   data_file <- as_data_file(ind_file)
-  saveRDS(list(sf_gage_rivers = sf_gage_rivers,
+  saveRDS(list(#sf_gage_rivers = sf_gage_rivers,
                sf_major_rivers = sf_major_rivers,
                sf_waterbodies = sf_waterbodies),
           data_file)

--- a/2_process/src/process_river_geoms.R
+++ b/2_process/src/process_river_geoms.R
@@ -1,5 +1,6 @@
 process_river_geoms <- function(ind_file,
                                 major_river_geoms_ind,
+                                gage_river_geoms_ind,
                                 waterbody_geoms_ind,
                                 river_geom_config) {
 
@@ -8,7 +9,7 @@ process_river_geoms <- function(ind_file,
   simplification_tolerance_m <- river_geom_config$simplification_tolerance_m
 
   sf_major_rivers <- readRDS(sc_retrieve(major_river_geoms_ind, remake_file = getOption("scipiper.remake_file")))
-  #sf_gage_rivers <- readRDS(sc_retrieve(gage_river_geoms_ind, remake_file = getOption("scipiper.remake_file")))
+  sf_gage_rivers <- readRDS(sc_retrieve(gage_river_geoms_ind, remake_file = getOption("scipiper.remake_file")))
   sf_waterbodies <- readRDS(sc_retrieve(waterbody_geoms_ind, remake_file = getOption("scipiper.remake_file")))
 
   outlets <- filter(sf_major_rivers,
@@ -29,20 +30,20 @@ process_river_geoms <- function(ind_file,
     st_cast("LINESTRING") %>%
     st_simplify(dTolerance = simplification_tolerance_m)
 
- # sf_gage_rivers <- sf_gage_rivers %>%
- #   group_by(site_id, up_down) %>%
- #   summarise() %>%
- #   st_cast("MULTILINESTRING") %>%
- #   ungroup() %>%
- #   st_line_merge() %>%
- #   st_cast("LINESTRING") %>%
- #   st_simplify(dTolerance = simplification_tolerance_m)
+  sf_gage_rivers <- sf_gage_rivers %>%
+    group_by(site_id, up_down) %>%
+    summarise() %>%
+    st_cast("MULTILINESTRING") %>%
+    ungroup() %>%
+    st_line_merge() %>%
+    st_cast("LINESTRING") %>%
+    st_simplify(dTolerance = simplification_tolerance_m)
 
   sf_waterbodies <- st_simplify(sf_waterbodies,
                                 dTolerance = simplification_tolerance_m)
 
   data_file <- as_data_file(ind_file)
-  saveRDS(list(#sf_gage_rivers = sf_gage_rivers,
+  saveRDS(list(sf_gage_rivers = sf_gage_rivers,
                sf_major_rivers = sf_major_rivers,
                sf_waterbodies = sf_waterbodies),
           data_file)

--- a/6_visualize/in/6_outro_gif_tasks_template.mustache
+++ b/6_visualize/in/6_outro_gif_tasks_template.mustache
@@ -29,7 +29,7 @@ targets:
       gage_sites_fun_a_{{last_task}},
       rdgs_fun_1,
       legend_fun_a_{{last_task}},
-      datetime_fun_a_{{last_task}},
+      timeline_fun_a_{{last_task}},
       cities_fun,
       watermark_fun)
 
@@ -52,7 +52,7 @@ targets:
       gage_sites_fun_a_{{last_task}},
       rdgs_fun_1,
       legend_fun_a_{{last_task}},
-      datetime_fun_a_{{last_task}},
+      timeline_fun_a_{{last_task}},
       cities_fun,
       watermark_fun)
 
@@ -75,7 +75,7 @@ targets:
       gage_sites_fun_a_{{last_task}},
       rdgs_fun_1,
       legend_fun_a_{{last_task}},
-      datetime_fun_a_{{last_task}},
+      timeline_fun_a_{{last_task}},
       cities_fun,
       watermark_fun)
 

--- a/6_visualize/in/6_outro_gif_tasks_template.mustache
+++ b/6_visualize/in/6_outro_gif_tasks_template.mustache
@@ -29,7 +29,6 @@ targets:
       gage_sites_fun_a_{{last_task}},
       rdgs_fun_1,
       legend_fun_a_{{last_task}},
-      timeline_fun_a_{{last_task}},
       cities_fun,
       watermark_fun)
 
@@ -52,7 +51,6 @@ targets:
       gage_sites_fun_a_{{last_task}},
       rdgs_fun_1,
       legend_fun_a_{{last_task}},
-      timeline_fun_a_{{last_task}},
       cities_fun,
       watermark_fun)
 
@@ -75,7 +73,6 @@ targets:
       gage_sites_fun_a_{{last_task}},
       rdgs_fun_1,
       legend_fun_a_{{last_task}},
-      timeline_fun_a_{{last_task}},
       cities_fun,
       watermark_fun)
 

--- a/6_visualize/src/prep_basemap_fun.R
+++ b/6_visualize/src/prep_basemap_fun.R
@@ -2,16 +2,16 @@ prep_basemap_fun <- function(focus_geoms_ind, secondary_geoms_ind = NULL, detail
 
   plot_fun <- function(){
     if (!is.null(secondary_geoms_ind)){
-      secondary_geoms <- readRDS(sc_retrieve(secondary_geoms_ind))
+      secondary_geoms <- readRDS(sc_retrieve(secondary_geoms_ind, remake_file = getOption("scipiper.remake_file")))
       plot(secondary_geoms, add = TRUE, lwd = 0.3, col = 'grey80', border = 'grey75') # should style args be in a config?
     }
 
     if (!is.null(detail_geoms_ind)){
-      detail_geoms <- readRDS(sc_retrieve(detail_geoms_ind))
+      detail_geoms <- readRDS(sc_retrieve(detail_geoms_ind, remake_file = getOption("scipiper.remake_file")))
       plot(detail_geoms, add = TRUE, lwd = 0.3, col = NA, border = 'grey95') # should style args be in a config?
     }
 
-    focus_geoms <- readRDS(sc_retrieve(focus_geoms_ind))
+    focus_geoms <- readRDS(sc_retrieve(focus_geoms_ind, remake_file = getOption("scipiper.remake_file")))
     plot(focus_geoms, add = TRUE, col = "grey95", border = 'grey75')
   }
   return(plot_fun)

--- a/6_visualize/src/prep_legend_fun.R
+++ b/6_visualize/src/prep_legend_fun.R
@@ -5,7 +5,7 @@ prep_legend_fun <- function(precip_bins, legend_styles, timesteps_ind, storm_poi
   y_pos <- match.arg(y_pos)
 
   if(is.na(DateTime)) {
-    timesteps <- readRDS(sc_retrieve(timesteps_ind))
+    timesteps <- readRDS(sc_retrieve(timesteps_ind), remake_file = getOption("scipiper.remake_file"))
     DateTime <- timesteps[1]
     rm(timesteps)
   }
@@ -48,7 +48,7 @@ prep_legend_fun <- function(precip_bins, legend_styles, timesteps_ind, storm_poi
 
     # plot precip bins and precip label
     precip_txt_y <- ybottom+2*bin_h*0.8
-    text(x_edge, precip_txt_y, labels = 'NOAA total rainfall amount (inches)', pos = txt_pos,
+    text(x_edge, precip_txt_y, labels = 'NOAA total rainfall (inches)', pos = txt_pos,
          cex=legend_text_cfg$cex, col=legend_text_cfg$col, family=legend_text_cfg$family)
     if (x_pos == 'left'){
       bin_j <- 1:nrow(precip_bins)
@@ -68,7 +68,7 @@ prep_legend_fun <- function(precip_bins, legend_styles, timesteps_ind, storm_poi
 
     # plot gage points legend
     gage_caveat_y <- ybottom+5*bin_h*1.02
-    text(x_edge, gage_caveat_y, labels = 'Selected USGS stream gages', pos = txt_pos,
+    text(x_edge, gage_caveat_y, labels = 'Select USGS stream gages', pos = txt_pos,
          cex=legend_text_cfg$cex, col=legend_text_cfg$col, family=legend_text_cfg$family)
     normal_y <- ybottom+4*bin_h
     points(dot_x, normal_y+center_to_txt_y, pch = 21, bg = legend_styles$gage_norm_col, col = NA, cex = 2)

--- a/6_visualize/src/prep_outro_funs.R
+++ b/6_visualize/src/prep_outro_funs.R
@@ -2,7 +2,7 @@ prep_outro_rdgs_fun <- function(rdg_ind="1_fetch/out/rapid_dep_sites.rds.ind", g
   # project from lat/lon to plot coordinates. . this properly belongs in a 2_process step, but we're releasing tomorrow
   proj_str <- "+proj=lcc +lat_1=34.83333333333334 +lat_2=32.5 +lat_0=31.83333333333333 +lon_0=-81 +x_0=609600 +y_0=0 +ellps=GRS80 +units=m +no_defs "
 
-  rdgs <- readRDS(sc_retrieve(rdg_ind))
+  rdgs <- readRDS(sc_retrieve(rdg_ind), remake_file = getOption("scipiper.remake_file"))
 
   if(length(rdgs) ==  0) {
     plot_fun <- function(){ return() }
@@ -53,7 +53,7 @@ prep_outro_allsites_fun <- function(allsites_ind="2_process/out/gage_sites_geom.
                                     gage_col_config, outro_placement, legend_text_cfg, opacity=1) {
 
   # gage_sites_geom.rds.ind is already projected for us
-  allsites <- readRDS(sc_retrieve(allsites_ind))
+  allsites <- readRDS(sc_retrieve(allsites_ind), remake_file = getOption("scipiper.remake_file"))
 
   if(opacity != 1) stop("opacity other than 1 not yet supported")
 

--- a/6_visualize/src/prep_precip_fun.R
+++ b/6_visualize/src/prep_precip_fun.R
@@ -15,6 +15,7 @@ prep_precip_fun <- function(precip_rasters, precip_bins, timestep){
   rm(precip_rasters, precip_bins, timestep)
 
   plot_fun <- function(){
+    par(mai = c(0,0,0,0))
     plot(one_precip_raster, add = TRUE, breaks = breaks, col = colors, legend = FALSE)
   }
   return(plot_fun)

--- a/6_visualize/src/prep_rivers_fun.R
+++ b/6_visualize/src/prep_rivers_fun.R
@@ -1,7 +1,7 @@
 
 prep_rivers_fun <- function(river_ind, rivers_cfg){
 
-  sf_rivers <- readRDS(sc_retrieve(river_ind))
+  sf_rivers <- readRDS(sc_retrieve(river_ind), remake_file = getOption("scipiper.remake_file"))
   marsh_fcodes <- c(46600, 44601, 44602)
 
   plot_fun <- function(){

--- a/6_visualize/src/prep_rivers_fun.R
+++ b/6_visualize/src/prep_rivers_fun.R
@@ -1,7 +1,7 @@
 
 prep_rivers_fun <- function(river_ind, rivers_cfg){
 
-  sf_rivers <- readRDS(sc_retrieve(river_ind), remake_file = getOption("scipiper.remake_file"))
+  sf_rivers <- readRDS(sc_retrieve(river_ind, remake_file = getOption("scipiper.remake_file")))
   marsh_fcodes <- c(46600, 44601, 44602)
 
   plot_fun <- function(){

--- a/6_visualize/src/visualize_utils.R
+++ b/6_visualize/src/visualize_utils.R
@@ -22,7 +22,7 @@ existing_png_tasks <- function(path='6_visualize/tmp', pattern='a_[[:digit:]]{8}
 
 timesteps_to_build <- function(timestep_ind, frame_step = 1) {
 
-  all_timestep <- readRDS(sc_retrieve(timestep_ind))
+  all_timestep <- readRDS(sc_retrieve(timestep_ind), remake_file = getOption("scipiper.remake_file"))
 
   timestep <- all_timestep[seq(1, by = frame_step, to = length(all_timestep))] %>%
     # ** skip the first frame! it is empty for sparks and causes a nasty blink between intro and storm frames:

--- a/viz_config-example.yml
+++ b/viz_config-example.yml
@@ -1,6 +1,6 @@
 storm_name: "Florence"
 # `storm_code` and `stn_event` can be commented out or deleted if there is not a storm track
-storm_code: al062018 # find the right code at https://www.nhc.noaa.gov/gis/archive_besttrack.php?year=2018
+storm_code: al062018 # find the right code at https://www.nhc.noaa.gov/gis/archive_besttrack.php?year=2021
 stn_event: 283
 dates:
   start: '2018-09-12 00:00:00'
@@ -32,7 +32,6 @@ gage_river_col: "#5d9ddc"
 lake_col: "#a2c7eb"
 marsh_col: NA
 ocean_col: "#e7f1fa"
-storm_line_col: "grey70"
 legend_text:
   cex: 1.5
   col: "#161616"

--- a/viz_config-example.yml
+++ b/viz_config-example.yml
@@ -1,7 +1,7 @@
 storm_name: "Florence"
 # `storm_code` and `stn_event` can be commented out or deleted if there is not a storm track
 storm_code: al062018 # find the right code at https://www.nhc.noaa.gov/gis/archive_besttrack.php?year=2021
-stn_event: 283
+stn_event: 283 # Can find code by looking at REST URLs here: https://stn.wim.usgs.gov/STNDataPortal/#
 dates:
   start: '2018-09-12 00:00:00'
   end: '2018-09-19 13:00:00'


### PR DESCRIPTION
Addresses most issues noted in https://github.com/USGS-VIZLAB/vizstorm-GIF/issues/239:
- Uses `nhdplusTools` to fetch river and waterbody geoms
- Adds sp stencil bug fix
- Adds `stn_Event` link to config and remove duplicate `storm_line_col`
- Removes dim to allow precip bind by date
- Directs `sc_retrieve` to remake over default to `getters.yml`
- Updates outro frames to use `timeline_fun` added during `Sally-2020`
- Adds `par` to plotting function for `precip_rasters` to correct misalignment with river geoms