### PR TITLE
Add target for creating a video & fix delays in the gif

### DIFF
--- a/6_visualize.yml
+++ b/6_visualize.yml
@@ -247,10 +247,10 @@ targets:
     command: combine_animation_frames_gif(
       gif_file=target_name,
       animation_cfg=animation_cfg,
+      intro_config = intro_config,
       frame_ind_intro = "6_visualize/log/6_intro_gif_tasks.ind",
       frame_ind_storm = "6_visualize/log/6_storm_gif_tasks.ind",
-      frame_ind_outro = "6_visualize/log/6_outro_gif_tasks.ind",
-      intro_config = intro_config)
+      frame_ind_outro = "6_visualize/log/6_outro_gif_tasks.ind")
   6_visualize/out/animation_a.gif.ind:
     command: gd_put(target_name, '6_visualize/out/animation_a.gif')
 
@@ -259,9 +259,9 @@ targets:
     command: combine_animation_frames_video(
       out_file=target_name,
       animation_cfg=animation_cfg,
+      intro_config = intro_config,
       frame_ind_intro = "6_visualize/log/6_intro_gif_tasks.ind",
       frame_ind_storm = "6_visualize/log/6_storm_gif_tasks.ind",
-      frame_ind_outro = "6_visualize/log/6_outro_gif_tasks.ind",
-      intro_config = intro_config)
+      frame_ind_outro = "6_visualize/log/6_outro_gif_tasks.ind")
   6_visualize/out/animation.mp4.ind:
     command: gd_put(target_name, '6_visualize/out/animation.mp4')

--- a/6_visualize.yml
+++ b/6_visualize.yml
@@ -31,6 +31,7 @@ targets:
   6_visualize:
     depends:
       - 6_visualize/out/animation_a.gif
+      - 6_visualize/out/animation_a.mp4
 
   # here we'll generate the components for basemap, focus_geoms, secondary_geoms,
   # adn storm_line. each of these components doesn't change over time. each
@@ -243,7 +244,7 @@ targets:
   animation_cfg:
     command: viz_config[I('frame_delay_cs')]
   6_visualize/out/animation_a.gif:
-    command: combine_animation_frames(
+    command: combine_animation_frames_gif(
       gif_file=target_name,
       animation_cfg=animation_cfg,
       frame_ind_intro = "6_visualize/log/6_intro_gif_tasks.ind",
@@ -252,3 +253,15 @@ targets:
       intro_config = intro_config)
   6_visualize/out/animation_a.gif.ind:
     command: gd_put(target_name, '6_visualize/out/animation_a.gif')
+
+  # Now combine into a video file
+  6_visualize/out/animation_a.mp4:
+    command: combine_animation_frames_video(
+      out_file=target_name,
+      animation_cfg=animation_cfg,
+      frame_ind_intro = "6_visualize/log/6_intro_gif_tasks.ind",
+      frame_ind_storm = "6_visualize/log/6_storm_gif_tasks.ind",
+      frame_ind_outro = "6_visualize/log/6_outro_gif_tasks.ind",
+      intro_config = intro_config)
+  6_visualize/out/animation.mp4.ind:
+    command: gd_put(target_name, '6_visualize/out/animation.mp4')

--- a/6_visualize/src/combine_animation_frames.R
+++ b/6_visualize/src/combine_animation_frames.R
@@ -1,4 +1,4 @@
-combine_animation_frames_video <- function(out_file, animation_cfg, frame_ind_intro=NULL, frame_ind_storm=NULL, frame_ind_outro=NULL, intro_config) {
+combine_animation_frames_video <- function(out_file, animation_cfg, intro_config, frame_ind_intro=NULL, frame_ind_storm=NULL, frame_ind_outro=NULL) {
 
   # Use ffmpeg to build a video
 
@@ -44,7 +44,7 @@ combine_animation_frames_video <- function(out_file, animation_cfg, frame_ind_in
   return(out_file)
 }
 
-combine_animation_frames_gif <- function(gif_file, animation_cfg, frame_ind_intro=NULL, frame_ind_storm=NULL, frame_ind_outro=NULL, intro_config) {
+combine_animation_frames_gif <- function(gif_file, animation_cfg, intro_config, frame_ind_intro=NULL, frame_ind_storm=NULL, frame_ind_outro=NULL) {
 
   # run imageMagick convert to build a gif
 

--- a/6_visualize/src/combine_animation_frames.R
+++ b/6_visualize/src/combine_animation_frames.R
@@ -79,24 +79,28 @@ combine_animation_frames_gif <- function(gif_file, animation_cfg, intro_config, 
   outro_delay <- 200
   final_delay <- 700
   freeze_delay <- 150
-  # **trash code for now:
+
   calc_delays <- function(delay, start_frame, end_frame){
     paste(paste(sprintf('-d%s "#', delay), seq(start_frame-1, end_frame-1), sep = '') %>%
             paste('"', sep = ''), collapse = " ")
   }
-  intro_delays <- calc_delays(intro_delay, 1, n_intro)
-  storm_delays <- calc_delays(storm_delay, n_intro+1, total_frames-n_outro-1)
-  # freeze the last storm frame too for as long as we are showing each outro frame:
-  last_storm_delay <- calc_delays(freeze_delay, total_frames-n_outro, total_frames-n_outro)
-  outro_delays <- calc_delays(outro_delay, total_frames-n_outro+1, total_frames-1)
-  final_delay <- calc_delays(final_delay, total_frames, total_frames)
 
-  gifsicle_command <- sprintf('gifsicle -b -O3 %s %s %s %s %s %s --colors 256', gif_file, intro_delays, storm_delays, last_storm_delay, outro_delays, final_delay)
+  intro_delay_str <- calc_delays(intro_delay, 1, n_intro)
+  storm_delay_str <- calc_delays(storm_delay, n_intro+1, total_frames-n_outro-1)
+  # freeze the last storm frame too for as long as we are showing each outro frame:
+  last_storm_delay_str <- calc_delays(freeze_delay, total_frames-n_outro, total_frames-n_outro)
+  outro_delay_str <- calc_delays(outro_delay, total_frames-n_outro+1, total_frames-1)
+  final_delay_str <- calc_delays(final_delay, total_frames, total_frames)
+
+  gifsicle_command <- sprintf('gifsicle -b -O3 %s %s %s %s %s %s --colors 256', gif_file,
+                              intro_delay_str, storm_delay_str, last_storm_delay_str,
+                              outro_delay_str, final_delay_str)
   system(gifsicle_command)
 }
 
 extract_filenames_from_ind <- function(ind_file) {
   filename_hash_list <- readLines(ind_file)
   only_names <- unlist(lapply(strsplit(filename_hash_list, ":"), `[`, 1))
-  return(only_names)
+  only_real_files <- na.omit(only_names) # sometimes there is an empty line at the end of the file that is read and turns into an NA
+  return(only_real_files)
 }


### PR DESCRIPTION
Fixes #242 by adding an additional target to `6_visualize.yml` - the mp4 file. In addition, I was noticing some funkiness in the two recent GIFs with how the final frames were timed (they didn't have the same, steady delay). I figured out it was due to an issue with NAs and fixed this for future GIF animations.